### PR TITLE
Provide a non-default hostname for CoreOS systems.

### DIFF
--- a/roles/coreos-bootstrap/tasks/main.yml
+++ b/roles/coreos-bootstrap/tasks/main.yml
@@ -38,3 +38,11 @@
   pip:
     name: "{{ item }}"
   with_items: pip_python_modules
+
+- name: Check configured hostname
+  shell: hostname
+  register: configured_hostname
+
+- name: Assign inventory name to unconfigured hostnames
+  shell: sh -c "echo \"{{inventory_hostname}}\" > /etc/hostname; hostname \"{{inventory_hostname}}\""
+  when: configured_hostname.stdout == 'localhost'


### PR DESCRIPTION
A freshly-installed CoreOS system does not always have a hostname configured.
This causes problems for etcd and BGP mesh configuration for Calico.
Assign the Ansible inventory name as hostname as part of CoreOS bootstrap,
if the hostname is the default ("localhost").