### PR TITLE
Implemented Dynamic Provisioning of PersistentVolumes with cinder

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -48,5 +48,5 @@ spec:
       path: {{ kube_config_dir }}
     name: kubernetes-config
   - hostPath:
-      path: /usr/share/ca-certificates
+      path: /etc/ssl/certs/
     name: ssl-certs-host

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -16,6 +16,10 @@ spec:
     - --service-account-private-key-file={{ kube_cert_dir }}/apiserver-key.pem
     - --root-ca-file={{ kube_cert_dir }}/ca.pem
     - --v={{ kube_log_level | default('2') }}
+{% if cloud_provider is defined and cloud_provider == "openstack" %}
+    - --cloud-provider=openstack
+    - --cloud-config={{ kube_config_dir }}/cloud_config
+{% endif %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1
@@ -30,6 +34,11 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
+{% if cloud_provider is defined and cloud_provider == "openstack" %}
+    - mountPath: {{ kube_config_dir }}/cloud_config
+      name: cloudconfig
+      readOnly: true
+{% endif %}
   volumes:
   - hostPath:
       path: {{ kube_cert_dir }}
@@ -37,3 +46,8 @@ spec:
   - hostPath:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
+{% if cloud_provider is defined and cloud_provider == "openstack" %}
+  - hostPath:
+      path: {{ kube_config_dir }}/cloud_config
+    name: cloudconfig
+{% endif %}

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -44,7 +44,7 @@ spec:
       path: {{ kube_cert_dir }}
     name: ssl-certs-kubernetes
   - hostPath:
-      path: /usr/share/ca-certificates
+      path: /etc/ssl/certs/
     name: ssl-certs-host
 {% if cloud_provider is defined and cloud_provider == "openstack" %}
   - hostPath:


### PR DESCRIPTION
The pull request #187 configured kubernetes in a way that allows cinder volumes to be used in pods. It did not enable the experimental feature of kubernetes 1.2 to provision PersistentVolumes dynamically with cinder.

When kubespray is deployed on OpenStack, the kube-controller-manager is now aware of the cluster and can create and delete cinder volumes automatically if the PersistentVolumeClaims are annotated accordingly.

This also fixes issue #189.