### PR TITLE
Changes to enable OpenContrail roles & generic Clouds

### DIFF
--- a/cluster-opencontrail.yml
+++ b/cluster-opencontrail.yml
@@ -1,0 +1,47 @@
+---
+
+#
+# To use Opencontrail with Kubernetes, you will need to do the following:
+# 1. checkout https://github.com/rackn/container-networking-ansible
+# 2. Copy the filters directory from container-network-ansible to this directory.
+# 3. Copy the roles/* directory content to the roles directory
+# 
+# Update your inventory file to use opencontrail as the network_plugin.
+# Update your inventory to have masters group that is the same as kube-master
+# Update your inventory to have nodes group that is the same as kube-node
+# Update your inventory to have a gateway group
+# 
+# Add vars to group_var file:
+# Publics IP Opencontrail should use to expose services.
+# opencontrail_public_subnet=192.0.2.0/24
+# opencontrail_kube_release=1.1
+#
+# See here for more info: https://github.com/rackn/container-networking-ansible
+#
+
+
+- hosts: k8s-cluster
+  roles:
+    - { role: adduser, tags: adduser }
+    - { role: download, tags: download }
+    - { role: kubernetes/preinstall, tags: preinstall }
+    - { role: etcd, tags: etcd }
+    - { role: docker, tags: docker, when: ansible_os_family != "CoreOS" }
+    - { role: kubernetes/node, tags: node }
+    - { role: network_plugin, tags: network, when: kube_network_plugin != 'opencontrail' }
+    - { role: opencontrail_facts, when: kube_network_plugin == 'opencontrail' }
+    - { role: opencontrail, when: kube_network_plugin == 'opencontrail' }
+
+- hosts: kube-master
+  roles:
+    - { role: kubernetes/master, tags: master }
+
+- hosts: k8s-cluster
+  roles:
+    - { role: opencontrail_facts, when: kube_network_plugin == 'opencontrail' }
+    - { role: opencontrail_provision, when: kube_network_plugin == 'opencontrail' }
+
+- hosts: k8s-cluster
+  roles:
+    - { role: dnsmasq, tags: dnsmasq }
+

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -22,6 +22,7 @@
   template:
     src: manifests/kube-proxy.manifest.j2
     dest: "{{ kube_manifest_dir }}/kube-proxy.manifest"
+  when: kube_network_plugin != "opencontrail"
 
 - name: Restart kubelet if binary changed
   command: /bin/true

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -16,7 +16,7 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 # KUBELET_PORT="--port=10250"
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname_override={{ inventory_hostname }}"
-{% if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] %}
+{% if inventory_hostname not in groups['kube-node'] %}
 KUBELET_REGISTER_NODE="--register-node=false"
 {% endif %}
 # location of the api-server
@@ -29,6 +29,9 @@ KUBELET_ARGS="--kubeconfig={{ kube_config_dir}}/kubelet.kubeconfig --config={{ k
 KUBELET_NETWORK_PLUGIN="--network_plugin=cni --network-plugin-dir=/etc/cni/net.d"
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}
 DOCKER_SOCKET="--docker-endpoint=unix:/var/run/weave/weave.sock"
+{% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin == "opencontrail" and inventory_hostname in groups['kube-node'] %}
+KUBELET_NETWORK_PLUGIN="--network_plugin={{ kube_network_plugin }}"
 {% endif %}
 # Should this cluster be allowed to run privileged docker containers
 KUBE_ALLOW_PRIV="--allow_privileged=true"

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -48,8 +48,8 @@
 
 - name: check cloud_provider value
   fail:
-    msg: "If set the 'cloud_provider' var must be set either to 'gce', 'aws' or 'openstack'"
-  when: cloud_provider is defined and cloud_provider not in ['gce', 'aws', 'openstack']
+    msg: "If set the 'cloud_provider' var must be set either to 'generic', gce', 'aws' or 'openstack'"
+  when: cloud_provider is defined and cloud_provider not in ['generic', 'gce', 'aws', 'openstack']
 
 - include: openstack-credential-check.yml
   when: cloud_provider is defined and cloud_provider == 'openstack'


### PR DESCRIPTION
Bringing the OpenContrail work into 1.2 playbooks from 1.1.  OpenContrail has it's own playbook for starting, so it will not impact the others.

With that, there are some very small conditional changes to make sure that we don't break opencontrail when it's being configured.

Also, adding OpenStack overloaded the cloudp-provider flag, so we need a "generic" version that allows us to create the flag without driving cloud specific behavior.