### PR TITLE
Add code to detect if epel is already installed and skip it if it is

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -48,8 +48,8 @@
 
 - name: check cloud_provider value
   fail:
-    msg: "If set the 'cloud_provider' var must be set either to 'gce', 'aws' or 'openstack'"
-  when: cloud_provider is defined and cloud_provider not in ['gce', 'aws', 'openstack']
+    msg: "If set the 'cloud_provider' var must be set either to 'generic', gce', 'aws' or 'openstack'"
+  when: cloud_provider is defined and cloud_provider not in ['generic', 'gce', 'aws', 'openstack']
 
 - include: openstack-credential-check.yml
   when: cloud_provider is defined and cloud_provider == 'openstack'
@@ -78,10 +78,17 @@
         ansible_distribution_major_version > 21
   changed_when: False
 
+- name: Check if epel-release-7-5.noarch is installed
+  command: rpm -q epel-release-7-5.noarch
+  register: epel_check
+  when: ansible_distribution in ["CentOS","RedHat"] and
+        ansible_distribution_major_version >= 7
+
 - name: Install epel-release on RedHat/CentOS
   command: rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   when: ansible_distribution in ["CentOS","RedHat"] and
-        ansible_distribution_major_version >= 7
+        ansible_distribution_major_version >= 7 and
+        epel_check.stdout.find('is not installed') != -1
   changed_when: False
 
 - name: Install packages requirements

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -78,17 +78,10 @@
         ansible_distribution_major_version > 21
   changed_when: False
 
-- name: Check if epel-release-7-5.noarch is installed
-  command: rpm -q epel-release-7-5.noarch
-  register: epel_check
+- name: Install epel-release on RedHat/CentOS
+  shell: rpm -qa | grep epel-release || rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   when: ansible_distribution in ["CentOS","RedHat"] and
         ansible_distribution_major_version >= 7
-
-- name: Install epel-release on RedHat/CentOS
-  command: rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  when: ansible_distribution in ["CentOS","RedHat"] and
-        ansible_distribution_major_version >= 7 and
-        epel_check.stdout.find('is not installed') != -1
   changed_when: False
 
 - name: Install packages requirements

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -48,7 +48,7 @@
 
 - name: check cloud_provider value
   fail:
-    msg: "If set the 'cloud_provider' var must be set either to 'generic', gce', 'aws' or 'openstack'"
+    msg: "If set the 'cloud_provider' var must be set either to 'generic', 'gce', 'aws' or 'openstack'"
   when: cloud_provider is defined and cloud_provider not in ['generic', 'gce', 'aws', 'openstack']
 
 - include: openstack-credential-check.yml


### PR DESCRIPTION
With the RHEL support, the code assumes that we have to install EPEL; however, that task incorrectly fails if it already installed.  This code will detect if the module is already in and then skip the install accordingly.

Also added option for generic cloud type.  The addition for OpenStack overloaded the "cloud type" flag from something that was just defined or not into something that had meaning.  This was causing a failure because the flag that to be set to something based on tests for OpenStack credentials.  Adding the "generic" type allows users who need some cloud behavior without having a specific target to use the flag correctly.