### PR TITLE
Remove need to pre-create writeable dir on CoreOS

### DIFF
--- a/roles/coreos-bootstrap/files/bootstrap.sh
+++ b/roles/coreos-bootstrap/files/bootstrap.sh
@@ -3,6 +3,8 @@ set -e
 
 BINDIR="/opt/bin"
 
+mkdir -p $BINDIR
+
 cd $BINDIR
 
 if [[ -e $BINDIR/.bootstrapped ]]; then


### PR DESCRIPTION
I *think* this closes #219. Regardless, I didn't want to have to bake my own CoreOS image before deploying with kargo. Simply making the /opt/bin directory at the beginning of the bootstrap script worked as expected for me. Tested against Packet hosts running CoreOS stable.