### PR TITLE
Fix issue with check_certs playbook

### DIFF
--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -20,7 +20,7 @@
 - name: "Check certs | check if a cert already exists"
   stat:
     path: "{{ kube_cert_dir }}/ca.pem"
-  register: kubecert 
+  register: kubecert
 
 - name: "Check_certs | Set 'sync_certs' to true"
   set_fact:
@@ -28,8 +28,8 @@
   when: >-
       {%- set certs = {'sync': False} -%}
       {%- for server in play_hosts
-         if (not hostvars[server].kubecert.stat.exists) or
-         (hostvars[server].kubecert.stat.checksum != kubecert_master.stat.checksum|default('')) -%}
+         if (not hostvars[server].kubecert.stat.exists|default(False)) or
+         (hostvars[server].kubecert.stat.checksum|default('') != kubecert_master.stat.checksum|default('')) -%}
          {%- set _ = certs.update({'sync': True}) -%}
       {%- endfor -%}
       {{ certs.sync }}


### PR DESCRIPTION
check_certs task "Check_certs | Set 'sync_certs' to true" was failing
due to the dict not existing, this sets defaults that allows the
correct behavior of the conditionals.