### PR TITLE
set vm box to be hashicorp hosted trusty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 *.retry
 inventory/vagrant_ansible_inventory
+temp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Kubespray Logo](http://s9.postimg.org/md5dyjl67/kubespray_logoandkubespray_small.png)
 
-# Deploy a production ready kubernetes cluster
+##Deploy a production ready kubernetes cluster
 
 - Can be deployed on **AWS, GCE, OpenStack or Baremetal**
 - **High available** cluster
@@ -10,61 +10,12 @@
 - Support most popular **Linux distributions**
 - **Continuous integration tests**
 
-# Getting Started
 
 To deploy the cluster you can use :
 
-## kargo-cli
-
-[**kargo-cli**](https://github.com/kubespray/kargo-cli)
- 
-## Vagrant
-
-Assuming you have Vagrant (1.8+) installed with virtualbox (it may work
-with vmware, but is untested) you should be able to launch a 3 node 
-Kubernetes cluster by simply running `$ vagrant up`.
-
-This will spin up 3 VMs and install kubernetes on them.  Once they are 
-completed you can connect to any of them by running 
-`$ vagrant ssh k8s-0[1..3]`.
-
-```
-$ vagrant up
-Bringing machine 'k8s-01' up with 'virtualbox' provider...
-Bringing machine 'k8s-02' up with 'virtualbox' provider...
-Bringing machine 'k8s-03' up with 'virtualbox' provider...
-==> k8s-01: Box 'bento/ubuntu-14.04' could not be found. Attempting to find and install...
-...
-...
-    k8s-03: Running ansible-playbook...
-
-PLAY [k8s-cluster] *************************************************************
-
-TASK [setup] *******************************************************************
-ok: [k8s-03]
-ok: [k8s-01]
-ok: [k8s-02]
-...
-...
-PLAY RECAP *********************************************************************
-k8s-01                     : ok=157  changed=66   unreachable=0    failed=0   
-k8s-02                     : ok=137  changed=59   unreachable=0    failed=0   
-k8s-03                     : ok=86   changed=51   unreachable=0    failed=0   
-
-$ vagrant ssh k8s-01
-vagrant@k8s-01:~$ kubectl get nodes
-NAME      STATUS    AGE
-k8s-01    Ready     45s
-k8s-02    Ready     45s
-k8s-03    Ready     45s
-```
-
-
-## Ansible
-
-**Ansible** usual commands
-
-# Further Reading
+* [**kargo-cli**](https://github.com/kubespray/kargo-cli)
+* **vagrant** by simply running `vagrant up`
+* **Ansible** usual commands
 
 A complete **documentation** can be found [**here**](https://docs.kubespray.io)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Kubespray Logo](http://s9.postimg.org/md5dyjl67/kubespray_logoandkubespray_small.png)
 
-##Deploy a production ready kubernetes cluster
+# Deploy a production ready kubernetes cluster
 
 - Can be deployed on **AWS, GCE, OpenStack or Baremetal**
 - **High available** cluster
@@ -10,12 +10,61 @@
 - Support most popular **Linux distributions**
 - **Continuous integration tests**
 
+# Getting Started
 
 To deploy the cluster you can use :
 
-* [**kargo-cli**](https://github.com/kubespray/kargo-cli)
-* **vagrant** by simply running `vagrant up`
-* **Ansible** usual commands
+## kargo-cli
+
+[**kargo-cli**](https://github.com/kubespray/kargo-cli)
+ 
+## Vagrant
+
+Assuming you have Vagrant (1.8+) installed with virtualbox (it may work
+with vmware, but is untested) you should be able to launch a 3 node 
+Kubernetes cluster by simply running `$ vagrant up`.
+
+This will spin up 3 VMs and install kubernetes on them.  Once they are 
+completed you can connect to any of them by running 
+`$ vagrant ssh k8s-0[1..3]`.
+
+```
+$ vagrant up
+Bringing machine 'k8s-01' up with 'virtualbox' provider...
+Bringing machine 'k8s-02' up with 'virtualbox' provider...
+Bringing machine 'k8s-03' up with 'virtualbox' provider...
+==> k8s-01: Box 'bento/ubuntu-14.04' could not be found. Attempting to find and install...
+...
+...
+    k8s-03: Running ansible-playbook...
+
+PLAY [k8s-cluster] *************************************************************
+
+TASK [setup] *******************************************************************
+ok: [k8s-03]
+ok: [k8s-01]
+ok: [k8s-02]
+...
+...
+PLAY RECAP *********************************************************************
+k8s-01                     : ok=157  changed=66   unreachable=0    failed=0   
+k8s-02                     : ok=137  changed=59   unreachable=0    failed=0   
+k8s-03                     : ok=86   changed=51   unreachable=0    failed=0   
+
+$ vagrant ssh k8s-01
+vagrant@k8s-01:~$ kubectl get nodes
+NAME      STATUS    AGE
+k8s-01    Ready     45s
+k8s-02    Ready     45s
+k8s-03    Ready     45s
+```
+
+
+## Ansible
+
+**Ansible** usual commands
+
+# Further Reading
 
 A complete **documentation** can be found [**here**](https://docs.kubespray.io)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,11 +11,12 @@ CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
 $num_instances = 3
 $instance_name_prefix = "k8s"
 $vm_gui = false
-$vm_memory = 1024
+$vm_memory = 1536
 $vm_cpus = 1
 $shared_folders = {}
 $forwarded_ports = {}
 $subnet = "172.17.8"
+$box = "bento/ubuntu-14.04"
 
 host_vars = {}
 
@@ -40,22 +41,7 @@ end
 Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
-
-  config.vm.box = "ubuntu-14.04"
-  config.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" % [$update_channel, $image_version]
-
-  ["vmware_fusion", "vmware_workstation"].each do |vmware|
-    config.vm.provider vmware do |v, override|
-      override.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant_vmware_fusion.json" % [$update_channel, $image_version]
-    end
-  end
-
-  config.vm.provider :virtualbox do |v|
-    # On VirtualBox, we don't have guest additions or a functional vboxsf
-    # in CoreOS, so tell Vagrant that so it can be smarter.
-    v.check_guest_additions = false
-    v.functional_vboxsf     = false
-  end
+  config.vm.box = $box
 
   # plugin conflict
   if Vagrant.has_plugin?("vagrant-vbguest") then
@@ -92,7 +78,8 @@ Vagrant.configure("2") do |config|
         "ip" => ip,
         "access_ip" => ip,
         "flannel_interface" => ip,
-        "flannel_backend_type" => "host-gw"
+        "flannel_backend_type" => "host-gw",
+        "local_release_dir" => "/vagrant/temp"
       }
       config.vm.network :private_network, ip: ip
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,8 @@ Vagrant.configure("2") do |config|
         "access_ip" => ip,
         "flannel_interface" => ip,
         "flannel_backend_type" => "host-gw",
-        "local_release_dir" => "/vagrant/temp"
+        "local_release_dir" => "/vagrant/temp",
+        "download_run_once" => "True"
       }
       config.vm.network :private_network, ip: ip
 
@@ -96,6 +97,7 @@ Vagrant.configure("2") do |config|
           ansible.host_key_checking = false
           ansible.raw_arguments = ["--forks=#{$num_instances}"]
           ansible.host_vars = host_vars
+          #ansible.tags = ['download']
           ansible.groups = {
             # The first three nodes should be etcd servers
             "etcd" => ["k8s-0[1:3]"],

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 local_release_dir: /tmp
 
+# if this is set to true will only download files once
+download_run_once: False
+
 # Versions
 kube_version: "v1.2.4"
 etcd_version: v2.2.5

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Create dest directories
   file: path={{local_release_dir}}/{{item.dest|dirname}} state=directory recurse=yes
   with_items: "{{ downloads }}"
+  run_once: "{{ download_run_once|bool }}"
 
 - name: Download items
   get_url:
@@ -11,6 +12,7 @@
     owner: "{{ item.owner|default(omit) }}"
     mode: "{{ item.mode|default(omit) }}"
   with_items: "{{ downloads }}"
+  run_once: "{{ download_run_once|bool }}"
 
 - name: Extract archives
   unarchive:
@@ -21,6 +23,7 @@
     copy: no
   when: "{{item.unarchive is defined and item.unarchive == True}}"
   with_items: "{{ downloads }}"
+  run_once: "{{ download_run_once|bool }}"
 
 - name: Fix permissions
   file:
@@ -30,3 +33,4 @@
     mode: "{{ item.mode|default(omit) }}"
   when: "{{item.unarchive is not defined or item.unarchive == False}}"
   with_items: "{{ downloads }}"
+  run_once: "{{ download_run_once|bool }}"


### PR DESCRIPTION
I accidently left in the old download URL for coreos
even after I switched the box name to be ubuntu, it
worked fine for me because I already had that box
locally so it didn't try to download.  This should
resolve this by using the official bento/ubuntu-14.04
box which is a nice minimal image.

We also allow the default behaviour of sharing folder to VMs

By doing this we can stage our download files in a shared location
and speed up subsequent runs significantly.

using a shared folder can cause race conditions for the download
role as it tries to download files on all the nodes to the same
shared path.  This adds a flag to run the tasks in the download
role on just one node.

