### PR TITLE
Synchronize certs in case they're missing

### DIFF
--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -14,6 +14,7 @@
 - name: "Check_certs | Set 'sync_certs' and 'gen_certs' to true"
   set_fact:
     gen_certs: true
+    sync_certs: true
   when: not kubecert_master.stat.exists
   run_once: true
 
@@ -33,4 +34,3 @@
          {%- set _ = certs.update({'sync': True}) -%}
       {%- endfor -%}
       {{ certs.sync }}
-  run_once: true


### PR DESCRIPTION
The run_once only sets the variable for the first host in the play,
which usually is the first master, which already has the certs. Ensure
we set it for all hosts in the current play, so they get certs
synchronized properly.