### PR TITLE
Issue 249/255: Support insecure registries / Ensure Docker Proxies get set on CoreOS

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -5,9 +5,10 @@
     - { role: download, tags: download }
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: etcd, tags: etcd }
-    - { role: docker, tags: docker, when: ansible_os_family != "CoreOS" }
+    - { role: docker, tags: docker }
     - { role: kubernetes/node, tags: node }
     - { role: network_plugin, tags: network }
+    - { role: docker_customization, tags: docker_customization }
 
 - hosts: kube-master
   roles:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -128,3 +128,8 @@ dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address')
 #http_proxy: ""
 #https_proxy: ""
 #no_proxy: ""
+
+##An list of insecure registries to allow docker to connect to
+##This may be helpful if you are running your own internal registry
+#insecure_registry: 
+# - "xxx.yyy.zzz:5000"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -19,7 +19,7 @@
           docker requires a minimum kernel version of
           {{ docker_kernel_min_version }} on
           {{ ansible_distribution }}-{{ ansible_distribution_version }}
-  when: ansible_kernel|version_compare(docker_kernel_min_version, "<")
+  when: (ansible_os_family != "CoreOS") and (ansible_kernel|version_compare(docker_kernel_min_version, "<"))
 
 
 - name: ensure docker repository public key is installed
@@ -29,6 +29,7 @@
     keyserver: "{{docker_repo_key_info.keyserver}}"
     state: present
   with_items: "{{ docker_repo_key_info.repo_keys }}"
+  when: ansible_os_family != "CoreOS"
 
 - name: ensure docker repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
@@ -36,7 +37,7 @@
     repo: "{{item}}"
     state: present
   with_items: "{{ docker_repo_info.repos }}"
-  when: docker_repo_info.repos|length > 0
+  when: (ansible_os_family != "CoreOS") and (docker_repo_info.repos|length > 0)
 
 - name: Configure docker repository on RedHat/CentOS
   copy:
@@ -51,21 +52,12 @@
     pkg: "{{item}}"
     state: present
   with_items: "{{ docker_package_info.pkgs }}"
-  when: docker_package_info.pkgs|length > 0
+  when: (ansible_os_family != "CoreOS") and (docker_package_info.pkgs|length > 0)
 
 - name: allow for proxies on systems using systemd
   include: systemd-proxies.yml
   when: ansible_service_mgr == "systemd" and
         (http_proxy is defined or https_proxy is defined or no_proxy is defined)
-
-- name: create docker defaults file
-  file: path=/etc/default/docker state=touch
-  when: insecure_registry is defined
-
-- name: allow for insecure registries in docker defaults
-  lineinfile: dest=/etc/default/docker line="INSECURE_REGISTRY=\"{% for registry in insecure_registry %}--insecure-registry={{ registry }} {% endfor %}\""
-  when: insecure_registry is defined
-  notify: restart docker
 
 - meta: flush_handlers
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -58,6 +58,15 @@
   when: ansible_service_mgr == "systemd" and
         (http_proxy is defined or https_proxy is defined or no_proxy is defined)
 
+- name: create docker defaults file
+  file: path=/etc/default/docker state=touch
+  when: insecure_registry is defined
+
+- name: allow for insecure registries in docker defaults
+  lineinfile: dest=/etc/default/docker line="INSECURE_REGISTRY=\"{% for registry in insecure_registry %}--insecure-registry={{ registry }} {% endfor %}\""
+  when: insecure_registry is defined
+  notify: restart docker
+
 - meta: flush_handlers
 
 - name: ensure docker service is started and enabled

--- a/roles/docker_customization/handlers/main.yml
+++ b/roles/docker_customization/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: restart docker
+  command: /bin/true
+  notify:
+    - reload systemd
+    - reload docker
+
+- name : reload systemd
+  shell: systemctl daemon-reload
+  when: ansible_service_mgr == "systemd"
+
+- name: reload docker
+  service:
+    name: docker
+    state: restarted

--- a/roles/docker_customization/tasks/main.yml
+++ b/roles/docker_customization/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: create docker defaults file
+  file: path=/etc/default/docker state=touch
+  when: insecure_registry is defined
+
+- name: allow for insecure registries (CoreOS/Debian)
+  lineinfile: dest=/etc/default/docker regexp='^DOCKER_OPTS=\"(.*)\"' line='DOCKER_OPTS=\"\1 {% for registry in insecure_registry %}--insecure-registry={{ registry }} {% endfor %}\"' backrefs=yes
+  when: insecure_registry is defined and (ansible_os_family == "CoreOS" or ansible_os_family == "Debian")
+  notify: restart docker
+
+- name: allow for insecure registries (CentOS/RHEL)
+  lineinfile: dest=/etc/default/docker regexp='^OPTIONS=\"(.*)\"' line='OPTIONS=\"\1 {% for registry in insecure_registry %}--insecure-registry={{ registry }} {% endfor %}\"' backrefs=yes
+  when: insecure_registry is defined and (ansible_os_family != "CoreOS" and ansible_os_family != "Debian")
+  notify: restart docker
+
+- meta: flush_handlers


### PR DESCRIPTION
Closes #249. A list of insecure registries will populate the INSECURE_REGISTRIES variable in /etc/defaults/docker. The docker daemon then pulls these variables upon launch.