### PR TITLE
removed os restriction for coreos

### DIFF
--- a/roles/kubernetes/preinstall/meta/main.yml
+++ b/roles/kubernetes/preinstall/meta/main.yml
@@ -2,4 +2,3 @@
 dependencies:
   - role: adduser
     user: "{{ addusers.kube }}"
-    when: ansible_os_family != 'CoreOS'


### PR DESCRIPTION
Resolves #262. Again, not sure why it was there, but I was able to create a cluster successfully after removing. 

@paulczar do you have any insight on whether merging this would cause any issues?