### PR TITLE
resolves coreos nodes not setting up docker proxies

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -3,7 +3,7 @@
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: etcd, tags: etcd }
-    - { role: docker, tags: docker, when: ansible_os_family != "CoreOS" }
+    - { role: docker, tags: docker }
     - { role: kubernetes/node, tags: node }
     - { role: network_plugin, tags: network }
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -19,8 +19,7 @@
           docker requires a minimum kernel version of
           {{ docker_kernel_min_version }} on
           {{ ansible_distribution }}-{{ ansible_distribution_version }}
-  when: ansible_kernel|version_compare(docker_kernel_min_version, "<")
-
+  when: (ansible_os_family != "CoreOS") and (ansible_kernel|version_compare(docker_kernel_min_version, "<"))
 
 - name: ensure docker repository public key is installed
   action: "{{ docker_repo_key_info.pkg_key }}"
@@ -29,6 +28,7 @@
     keyserver: "{{docker_repo_key_info.keyserver}}"
     state: present
   with_items: "{{ docker_repo_key_info.repo_keys }}"
+  when: ansible_os_family != "CoreOS"
 
 - name: ensure docker repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
@@ -36,7 +36,7 @@
     repo: "{{item}}"
     state: present
   with_items: "{{ docker_repo_info.repos }}"
-  when: docker_repo_info.repos|length > 0
+  when: (ansible_os_family != "CoreOS") and (docker_repo_info.repos|length > 0)
 
 - name: Configure docker repository on RedHat/CentOS
   copy:
@@ -51,7 +51,7 @@
     pkg: "{{item}}"
     state: present
   with_items: "{{ docker_package_info.pkgs }}"
-  when: docker_package_info.pkgs|length > 0
+  when: (ansible_os_family != "CoreOS") and (docker_package_info.pkgs|length > 0)
 
 - name: allow for proxies on systems using systemd
   include: systemd-proxies.yml


### PR DESCRIPTION
Resolves #255. Just moves the os_family checks into the main task so that the proxy setup step can occur.