### PR TITLE
provides initial docker options support

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -128,3 +128,7 @@ dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address')
 #http_proxy: ""
 #https_proxy: ""
 #no_proxy: ""
+
+##A string of extra options to pass to the docker daemon.
+##This string should be exactly as you wish it to appear.
+#docker_options: ""

--- a/roles/network_plugin/calico/templates/docker
+++ b/roles/network_plugin/calico/templates/docker
@@ -1,8 +1,8 @@
 # Deployed by Ansible
 {% if ansible_service_mgr in ["sysvinit","upstart"] and kube_network_plugin == "flannel" and ansible_os_family == "Debian" %}
-DOCKER_OPTS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
+DOCKER_OPTS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"
 {% elif kube_network_plugin == "flannel" and ansible_os_family == "RedHat" %}
-DOCKER_NETWORK_OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
+DOCKER_NETWORK_OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"
 {% elif kube_network_plugin == "flannel" %}
-OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
+OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"
 {% endif %}

--- a/roles/network_plugin/flannel/templates/docker
+++ b/roles/network_plugin/flannel/templates/docker
@@ -1,7 +1,7 @@
 # Deployed by Ansible
 {% if (ansible_service_mgr in ["sysvinit","upstart"] and kube_network_plugin == "flannel" and ansible_os_family == "Debian") or
    (kube_network_plugin == "flannel" and ansible_os_family == "CoreOS") %}
-DOCKER_OPTS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
+DOCKER_OPTS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"
 {% elif kube_network_plugin == "flannel" %}
-OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
+OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"
 {% endif %}

--- a/roles/network_plugin/weave/templates/docker
+++ b/roles/network_plugin/weave/templates/docker
@@ -1,2 +1,2 @@
 # Deployed by Ansible
-DOCKER_OPTS=""
+DOCKER_OPTS="{% if docker_options is defined %}{{ docker_options }}{% endif %}"


### PR DESCRIPTION
closes #265. Provides a field in all.yml for a string of docker options. This string is applied to each network_plugin template if defined. I found that the Docker daemon only respected a single definition of DOCKER_OPTS, etc., so the if statement is present in the initial line for the template. Works as expected on CoreOS in AWS.

As an aside, need to revisit the templates themselves, as the Calico template seems to be pointing toward flannel_mtu values and other flannel things. I have not fooled with Calico, so it may deploy just fine, but it may be worth someone fixing these inconsistencies for clarity.