### PR TITLE
example env allow insecure-registry

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -124,11 +124,13 @@ dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address')
 #    balance roundrobin
 # apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
 
-##Set these proxy values in order to update docker daemon to use proxies
-#http_proxy: ""
-#https_proxy: ""
-#no_proxy: ""
+## Set these proxy values in order to update docker daemon to use proxies
+# http_proxy: ""
+# https_proxy: ""
+# no_proxy: ""
 
-##A string of extra options to pass to the docker daemon.
-##This string should be exactly as you wish it to appear.
-#docker_options: ""
+## A string of extra options to pass to the docker daemon.
+## This string should be exactly as you wish it to appear.
+## An obvious use case is allowing insecure-registry access
+## to self hosted registries like so:
+docker_options: "--insecure-registry={{ kube_service_addresses }}"


### PR DESCRIPTION
Many use cases of k8s involve running a local
registry, chances are the person running this
will learn the hard way that they need to allow
insecure registry on the `kube_service_addresses`
network.

We should just default to settings this in
`inventory/group_vars/all.yml` to help reduce
potential friction for first time users.