### PR TITLE
Fix order in restart kubelet to fix systemd reload

### DIFF
--- a/roles/kubernetes/node/handlers/main.yml
+++ b/roles/kubernetes/node/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
-- name: reload systemd
-  command: systemctl daemon-reload
-  when: ansible_service_mgr == "systemd"
-
 - name: restart kubelet
   command: /bin/true
   notify:
     - reload systemd
     - reload kubelet
+
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: ansible_service_mgr == "systemd"
 
 - name: reload kubelet
   service:


### PR DESCRIPTION
Systemd reload before reload kubelet was failing because its definition was before "restart kubelet". Its definition should be after the notify hook.