### PR TITLE
Force install of specified docker version, fixes #295

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -48,7 +48,8 @@
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
   args:
-    pkg: "{{item}}"
+    pkg: "{{item.name}}"
+    force: "{{item.force|default(omit)}}"
     state: present
   with_items: "{{ docker_package_info.pkgs }}"
   when: (ansible_os_family != "CoreOS") and (docker_package_info.pkgs|length > 0)

--- a/roles/docker/vars/centos-6.yml
+++ b/roles/docker/vars/centos-6.yml
@@ -5,7 +5,7 @@ docker_kernel_min_version: '2.6.32-431'
 docker_package_info:
   pkg_mgr: yum
   pkgs:
-    - docker-io
+    - name: docker-io
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -9,7 +9,8 @@ docker_versioned_pkg:
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version] }}"
+      force: yes
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/docker/vars/fedora-20.yml
+++ b/roles/docker/vars/fedora-20.yml
@@ -5,7 +5,7 @@ docker_kernel_min_version: '0'
 docker_package_info:
   pkg_mgr: yum
   pkgs:
-    - docker-io
+    - name: docker-io
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/docker/vars/fedora.yml
+++ b/roles/docker/vars/fedora.yml
@@ -8,7 +8,7 @@ docker_versioned_pkg:
 docker_package_info:
   pkg_mgr: dnf
   pkgs:
-    - "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version] }}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/docker/vars/redhat.yml
+++ b/roles/docker/vars/redhat.yml
@@ -3,7 +3,7 @@ docker_kernel_min_version: '0'
 docker_package_info:
   pkg_mgr: yum
   pkgs:
-    - docker-engine
+    - name: docker-engine
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/docker/vars/ubuntu-16.04.yml
+++ b/roles/docker/vars/ubuntu-16.04.yml
@@ -10,7 +10,8 @@ docker_versioned_pkg:
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version] }}"
+      force: yes
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -10,7 +10,8 @@ docker_versioned_pkg:
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version] }}"
+      force: yes
 
 docker_repo_key_info:
   pkg_key: apt_key


### PR DESCRIPTION
This allows Ubuntu/Debian to downgrade Docker version if
a newer version is installed, instead of failing.