### PR TITLE
Add settable flannel image tag & image repo

### DIFF
--- a/roles/network_plugin/flannel/defaults/main.yml
+++ b/roles/network_plugin/flannel/defaults/main.yml
@@ -10,3 +10,10 @@ flannel_public_ip: "{{ access_ip|default(ip|default(ansible_default_ipv4.address
 # You can choose what type of flannel backend to use
 # please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
 flannel_backend_type: "vxlan"
+
+
+flannel_server_helper_image_repo: "gcr.io/google_containers/flannel-server-helper"
+flannel_server_helper_image_tag: "0.1"
+
+flannel_image_repo: "quay.io/coreos/flannel"
+flannel_image_tag: "0.5.5"

--- a/roles/network_plugin/flannel/templates/flannel-pod.yml
+++ b/roles/network_plugin/flannel/templates/flannel-pod.yml
@@ -17,7 +17,7 @@
           path: "/etc/flannel-network.json"
     containers:
       - name: "flannel-server-helper"
-        image: "gcr.io/google_containers/flannel-server-helper:0.1"
+        image: "{{ flannel_server_helper_image_repo }}:{{ flannel_server_helper_image_tag }}"
         args:
           - "--network-config=/etc/flannel-network.json"
           - "--etcd-prefix=/{{ cluster_name }}/network"
@@ -27,7 +27,7 @@
             mountPath: "/etc/flannel-network.json"
         imagePullPolicy: "Always"
       - name: "flannel-container"
-        image: "quay.io/coreos/flannel:0.5.5"
+        image: "{{ flannel_image_repo }}:{{ flannel_image_tag }}"
         command:
           - "/bin/sh"
           - "-c"


### PR DESCRIPTION
New settings with defaults:
flannel_server_helper_image_repo: "gcr.io/google_containers/"
flannel_server_helper_image_tag: "0.1"
flannel_image_repo: "quay.io/coreos/flannel"
flannel_image_tag: "0.5.5"