### PR TITLE
[WIP] Update apt cache as for prerequisites as well

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -68,8 +68,12 @@
   yum: update_cache=yes name='*'
   when: ansible_pkg_mgr == 'yum'
 
+- name: Update package management cache (APT)
+  apt: update_cache=yes name='*' cache_valid_time=3600
+  when: ansible_pkg_mgr == 'apt'
+
 - name: Install latest version of python-apt for Debian distribs
-  apt: name=python-apt state=latest update_cache=yes cache_valid_time=3600
+  apt: name=python-apt state=latest
   when: ansible_os_family == "Debian"
 
 - name: Install python-dnf for latest RedHat versions


### PR DESCRIPTION
The task kubernetes/preinstall : Install packages requirements
shall not fail

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>