### PR TITLE
Change calicoctl deployment to use container

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -8,6 +8,8 @@ download_run_once: False
 include_vars: kube_versions.yml
 
 etcd_version: v3.0.1
+#TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
+# after migration to container download
 calico_version: v0.20.0
 calico_cni_version: v1.3.1
 weave_version: v1.5.0
@@ -18,27 +20,17 @@ apiserver_download_url: "https://storage.googleapis.com/kargo/{{kube_version}}_k
 kubectl_download_url: "https://storage.googleapis.com/kargo/{{kube_version}}_kubernetes-kubectl"
 
 etcd_download_url: "https://storage.googleapis.com/kargo/{{etcd_version}}_etcd"
-calico_download_url: "https://storage.googleapis.com/kargo/{{calico_version}}_calico"
 calico_cni_download_url: "https://storage.googleapis.com/kargo/{{calico_cni_version}}_calico-cni-plugin"
 calico_cni_ipam_download_url: "https://storage.googleapis.com/kargo/{{calico_cni_version}}_calico-cni-plugin-ipam"
 weave_download_url: "https://storage.googleapis.com/kargo/{{weave_version}}_weave"
 
 # Checksums
-calico_checksum: "0d1d15c03ea53cc1a16f2faf02626ed8951829ece410a36fdb93e5a19fbab68d"
 calico_cni_checksum: "ac05cb9254b5aaa5822cf10325983431bd25489147f2edf9dec7e43d99c43e77"
 calico_cni_ipam_checksum: "3df6951a30749c279229e7e318e74ac4e41263996125be65257db7cd25097273"
 weave_checksum: "28d2c4e2b1ad8600da69882501eba697679aea10a5e61c769aa3a9ee72b0d89a"
 etcd_checksum: "7e5d8db2b8a7cec7a93e531c8ae0f3108c66c7d896a2fb6d8768c067923ce0aa"
 
 downloads:
-  calico:
-    dest: calico/bin/calicoctl
-    version: "{{calico_version}}"
-    sha256: "{{ calico_checksum }}"
-    source_url: "{{ calico_download_url }}"
-    url: "{{ calico_download_url }}"
-    owner: "root"
-    mode: "0755"
   calico_cni_plugin:
     dest: calico/bin/calico
     version: "{{calico_cni_version}}"

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -4,3 +4,5 @@ nat_outgoing: true
 
 # cloud_provider can only be set to 'gce' or 'aws'
 # cloud_provider:
+calicoctl_image_repo: calico/ctl
+calicoctl_image_tag: "{{ calico_version }}"

--- a/roles/network_plugin/calico/meta/main.yml
+++ b/roles/network_plugin/calico/meta/main.yml
@@ -1,8 +1,6 @@
 ---
 dependencies:
   - role: download
-    file: "{{ downloads.calico }}"
-  - role: download
     file: "{{ downloads.calico_cni_plugin }}"
   - role: download
     file: "{{ downloads.calico_cni_plugin_ipam }}"

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -19,10 +19,15 @@
 
 - meta: flush_handlers
 
-- name: Calico | Install calicoctl bin
-  command: rsync -piu "{{ local_release_dir }}/calico/bin/calicoctl" "{{ bin_dir }}/calicoctl"
-  register: calico_copy
+- name: Calico | Install calicoctl container script
+  template:
+    src: calicoctl-container.j2
+    dest: "{{ bin_dir }}/calicoctl"
+    mode: 0755
+    owner: root
+    group: root
   changed_when: false
+  notify: restart calico-node
 
 - name: Calico | Install calico cni bin
   command: rsync -piu "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico"
@@ -31,9 +36,6 @@
 - name: Calico | Install calico-ipam cni bin
   command: rsync -piu "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico-ipam"
   changed_when: false
-
-- name: Calico | install calicoctl
-  file: path={{ bin_dir }}/calicoctl mode=0755 state=file
 
 - name: Calico | wait for etcd
   wait_for:
@@ -108,21 +110,12 @@
     state: started
     enabled: yes
 
-- name: Calico | Restart calico if binary changed
-  service:
-    name: calico-node
-    state: restarted
-  when: calico_copy.stdout_lines
-
 - name: Calico | Disable node mesh
   shell: "{{ bin_dir }}/calicoctl bgp node-mesh off"
-  environment:
-     ETCD_AUTHORITY: "127.0.0.1:2379"
   when: peer_with_router|default(false) and inventory_hostname in groups['kube-node']
 
 - name: Calico | Configure peering with router(s)
   shell: "{{ bin_dir }}/calicoctl node bgp peer add {{ item.router_id }} as {{ item.as }}"
-  environment:
-     ETCD_AUTHORITY: "127.0.0.1:2379"
   with_items: peers
   when: peer_with_router|default(false) and inventory_hostname in groups['kube-node']
+

--- a/roles/network_plugin/calico/templates/calicoctl-container.j2
+++ b/roles/network_plugin/calico/templates/calicoctl-container.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+/usr/bin/docker run --privileged --rm \
+--net=host -e ETCD_AUTHORITY=127.0.0.1:2379 \
+-v /usr/bin/docker:/usr/bin/docker \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v /var/run/calico:/var/run/calico \
+{{ calicoctl_image_repo }}:{{ calicoctl_image_tag}} \
+$@

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -12,28 +12,17 @@ weave_version: v1.5.0
 # Download URL's
 kube_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kube_version }}/bin/linux/amd64"
 etcd_download_url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
-calico_download_url: "https://github.com/Metaswitch/calico-docker/releases/download/{{calico_version}}/calicoctl"
 calico_cni_download_url: "https://github.com/projectcalico/calico-cni/releases/download/{{calico_cni_version}}/calico"
 calico_cni_ipam_download_url: "https://github.com/projectcalico/calico-cni/releases/download/{{calico_cni_version}}/calico-ipam"
 weave_download_url: "https://github.com/weaveworks/weave/releases/download/{{weave_version}}/weave"
 
 # Checksums
-calico_checksum: "0d1d15c03ea53cc1a16f2faf02626ed8951829ece410a36fdb93e5a19fbab68d"
 calico_cni_checksum: "ac05cb9254b5aaa5822cf10325983431bd25489147f2edf9dec7e43d99c43e77"
 calico_cni_ipam_checksum: "3df6951a30749c279229e7e318e74ac4e41263996125be65257db7cd25097273"
 weave_checksum: "28d2c4e2b1ad8600da69882501eba697679aea10a5e61c769aa3a9ee72b0d89a"
 etcd_checksum: "7e5d8db2b8a7cec7a93e531c8ae0f3108c66c7d896a2fb6d8768c067923ce0aa"
 
 downloads:
-  - name: calico
-    dest: calico/bin/calicoctl
-    version: "{{calico_version}}"
-    sha256: "{{ calico_checksum }}"
-    source_url: "{{ calico_download_url }}"
-    url: "{{ calico_download_url }}"
-    owner: "root"
-    mode: "0755"
-
   - name: calico-cni-plugin
     dest: calico/bin/calico
     version: "{{calico_cni_version}}"


### PR DESCRIPTION
Improves upgradability of calicoctl by leveraging docker tags.

Calicoctl always runs from a temporary container that is deleted after use. It has volume mounts for docker and calico sockets so that it can launch calico-node container and do status checks.