### PR TITLE
Support --ipip option for calico pool

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -2,6 +2,9 @@
 # Enables Internet connectivity from containers
 nat_outgoing: true
 
+# Use IP-over-IP encapsulation across hosts
+ipip: false
+
 # cloud_provider can only be set to 'gce' or 'aws'
 # cloud_provider:
 calicoctl_image_repo: calico/ctl

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -54,7 +54,14 @@
   command: "{{ bin_dir }}/calicoctl pool add {{ kube_pods_subnet }}"
   run_once: true
   when: calico_conf.status == 404 and cloud_provider is not defined
-        and not nat_outgoing|default(false) or
+        and not nat_outgoing|default(false) and not ipip|default(false) or
+        (nat_outgoing|default(false) and peer_with_router|default(false))
+
+- name: Calico | Configure calico network pool with IP-over-IP encapsulation
+  command: "{{ bin_dir }}/calicoctl pool add {{ kube_pods_subnet }} --ipip"
+  run_once: true
+  when: calico_conf.status == 404 and cloud_provider is not defined
+        and not nat_outgoing|default(false) and ipip|default(false) or
         (nat_outgoing|default(false) and peer_with_router|default(false))
 
 - name: Calico | Configure calico network pool for cloud
@@ -67,6 +74,14 @@
   run_once: true
   when: calico_conf.status == 404 and cloud_provider is not defined
         and nat_outgoing|default(false) and not peer_with_router|default(false)
+        and not ipip|default(false)
+
+- name: Calico | Configure calico network pool with nat outgoing and IP-over-IP encapsulation
+  command: "{{ bin_dir}}/calicoctl pool add {{ kube_pods_subnet }} --nat-outgoing --ipip"
+  run_once: true
+  when: calico_conf.status == 404 and cloud_provider is not defined
+        and nat_outgoing|default(false) and not peer_with_router|default(false)
+        and ipip|default(false)
 
 - name: Calico | Get calico configuration from etcd
   uri:


### PR DESCRIPTION
Adds new boolean configuration variable for calico network plugin
`ipip`. When it's enabled calico pool is created with '--ipip'
option (IP-over-IP encapsulation across hosts)