### PR TITLE
Move kubectl to docker container

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -68,3 +68,11 @@
     state: started
   with_items:
     - docker
+
+- name: add ansible_user to docker group
+  user:
+    name: "{{ ansible_user }}"
+    groups: docker
+    append: yes
+  when: ansible_user is defined and ansible_user != "root"
+

--- a/roles/kubernetes/master/meta/main.yml
+++ b/roles/kubernetes/master/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - role: download
-    file: "{{ downloads.kubernetes_kubectl }}"
+  - role: download # For kube_version variable
+    file: "{{ downloads.nothing }}"
   - { role: etcd }
   - { role: kubernetes/node }

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -7,9 +7,11 @@
     dest: /etc/bash_completion.d/kubectl.sh
   when: ansible_os_family in ["Debian","RedHat"]
 
-- name: Copy kubectl binary
-  command: rsync -piu "{{ local_release_dir }}/kubernetes/bin/kubectl" "{{ bin_dir }}/kubectl"
-  changed_when: false
+- name: Create kubectl launcher
+  template:
+    src: kubectl-container.j2
+    dest: "{{ bin_dir }}/kubectl"
+  register: kubectl_launcher
 
 - meta: flush_handlers
 

--- a/roles/kubernetes/master/templates/kubectl-container.j2
+++ b/roles/kubernetes/master/templates/kubectl-container.j2
@@ -1,0 +1,7 @@
+#!/bin/bash
+# /etc/kubernetes included in case kubeconfig and/or certs used
+/usr/bin/docker run --rm --net=host \
+-v /etc/kubernetes:/etc/kubernetes:ro \
+{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} \
+/hyperkube kubectl \
+$@


### PR DESCRIPTION
Nearly the last stage of moving all components to containers.
Kubectl will be called from hyperkube image.

Remaining tasks:
 * Move kube_version variable to kubernetes/preinstall
 * Drop placeholder download.nothing requirement