### PR TITLE
Copy kubectl from docker container

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -15,8 +15,6 @@ calico_cni_version: v1.3.1
 weave_version: v1.5.0
 
 # Download URL's
-kubectl_download_url: "https://storage.googleapis.com/kargo/{{kube_version}}_kubernetes-kubectl"
-
 etcd_download_url: "https://storage.googleapis.com/kargo/{{etcd_version}}_etcd"
 calico_cni_download_url: "https://storage.googleapis.com/kargo/{{calico_cni_version}}_calico-cni-plugin"
 calico_cni_ipam_download_url: "https://storage.googleapis.com/kargo/{{calico_cni_version}}_calico-cni-plugin-ipam"
@@ -61,14 +59,6 @@ downloads:
     url: "{{ etcd_download_url }}"
     unarchive: true
     owner: "etcd"
-    mode: "0755"
-  kubernetes_kubectl:
-    dest: kubernetes/bin/kubectl
-    version: "{{kube_version}}"
-    sha256: "{{vars['kube_checksum'][kube_version]['kubectl']}}"
-    source_url: "{{ kubectl_download_url }}"
-    url: "{{ kubectl_download_url }}"
-    owner: "kube"
     mode: "0755"
   nothing:
     enabled: false

--- a/roles/download/vars/kube_versions.yml
+++ b/roles/download/vars/kube_versions.yml
@@ -1,12 +1,1 @@
-kube_checksum:
-    v1.2.2:
-        kubectl: 473e6924569fba30d4a50cecdc2cae5f31d97d1f662463e85b74a472105dcff4
-    v1.2.3:
-        kubectl_checksum: 394853edd409a721bcafe4f1360009ef9f845050719fe7d6fc7176f45cc92a8c
-    v1.2.4:
-        kubectl: dac61fbd506f7a17540feca691cd8a9d9d628d59661eebce788a50511f578897
-    v1.2.5:
-        kubectl: 5526a496a84701015485e32c86486e2f23599f7a865164f546e619c6a62f7f19
-    v1.3.0:
-        kubectl: f40b2d0ff33984e663a0dea4916f1cb9041abecc09b11f9372cdb8049ded95dc
 kube_version: v1.3.0

--- a/roles/kubernetes/master/meta/main.yml
+++ b/roles/kubernetes/master/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - role: download
-    file: "{{ downloads.kubernetes_kubectl }}"
+  - role: download # For kube_version variable
+    file: "{{ downloads.nothing }}"
   - { role: etcd }
   - { role: kubernetes/node }

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -7,9 +7,10 @@
     dest: /etc/bash_completion.d/kubectl.sh
   when: ansible_os_family in ["Debian","RedHat"]
 
-- name: Copy kubectl binary
-  command: rsync -piu "{{ local_release_dir }}/kubernetes/bin/kubectl" "{{ bin_dir }}/kubectl"
+- name: Copy kubectl from hyperkube container
+  command: "/usr/bin/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp /hyperkube /systembindir/kubectl"
   changed_when: false
+  register: kubectl_launcher
 
 - meta: flush_handlers
 

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -10,7 +10,6 @@ calico_cni_version: v1.3.1
 weave_version: v1.5.0
 
 # Download URL's
-kube_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kube_version }}/bin/linux/amd64"
 etcd_download_url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
 calico_cni_download_url: "https://github.com/projectcalico/calico-cni/releases/download/{{calico_cni_version}}/calico"
 calico_cni_ipam_download_url: "https://github.com/projectcalico/calico-cni/releases/download/{{calico_cni_version}}/calico-ipam"
@@ -58,13 +57,4 @@ downloads:
     url: "{{ etcd_download_url }}"
     unarchive: true
     owner: "etcd"
-    mode: "0755"
-
-  - name: kubernetes-kubectl
-    dest: kubernetes/bin/kubectl
-    version: "{{kube_version}}"
-    sha256: "{{vars['kube_checksum'][kube_version]['kubectl']}}"
-    source_url: "{{ kube_download_url }}/kubectl"
-    url: "{{ kube_download_url }}/kubectl"
-    owner: "kube"
     mode: "0755"

--- a/roles/uploads/vars/kube_versions.yml
+++ b/roles/uploads/vars/kube_versions.yml
@@ -1,17 +1,1 @@
-kube_checksum:
-    v1.2.2:
-        kube_apiserver: eb1bfd8b877052cbd1991b8c429a1d06661f4cb019905e20e128174f724e16de
-        kubectl: 473e6924569fba30d4a50cecdc2cae5f31d97d1f662463e85b74a472105dcff4
-    v1.2.3:
-        kube_apiserver_checksum: ebaeeeb72cb29b358337b330617a96355ff2d08a5a523fc1a81beba36cc9d6f9
-        kubectl_checksum: 394853edd409a721bcafe4f1360009ef9f845050719fe7d6fc7176f45cc92a8c
-    v1.2.4:
-        kube_apiserver: 6ac99b36b02968459e026fcfc234207c66064b5e11816b69dd8fc234b2ffec1e
-        kubectl: dac61fbd506f7a17540feca691cd8a9d9d628d59661eebce788a50511f578897
-    v1.2.5:
-        kube_apiserver: fbe8296ad4b194c06f6802a126d35cd2887dc1aded308d4da2b580f270412b33
-        kubectl: 5526a496a84701015485e32c86486e2f23599f7a865164f546e619c6a62f7f19
-    v1.3.0:
-        kube_apiserver: 431cd312984a29f45590138e990d5c4d537b069b71f2587a72414fabc4fcffdd
-        kubectl: f40b2d0ff33984e663a0dea4916f1cb9041abecc09b11f9372cdb8049ded95dc
 kube_version: v1.3.0


### PR DESCRIPTION
Nearly the last stage of source all components to containers.
Kubectl will be called from hyperkube image.

Remaining tasks:
 * Move kube_version variable to kubernetes/preinstall
 * Drop placeholder download.nothing requirement