### PR TITLE
Fix etcd standalone deployment

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -1,9 +1,15 @@
 ---
-- hosts: k8s-cluster
+- hosts: etcd
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: etcd, tags: etcd }
     - { role: docker, tags: docker }
+
+- hosts: k8s-cluster
+  roles:
+    - { role: kubernetes/preinstall, tags: preinstall }
+    - { role: docker, tags: docker }
+    - { role: etcd, tags: etcd }
     - { role: kubernetes/node, tags: node }
     - { role: network_plugin, tags: network }
 

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -18,7 +18,7 @@
   when: ansible_service_mgr == "systemd"
 
 - name: wait for etcd up
-  uri: url=http://localhost:2379/health
+  uri: url="http://{% if is_etcd_master %}{{ etcd_address }}{% else %}127.0.0.1{% endif %}:2379/health"
   register: result
   until: result.status == 200
   retries: 10

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -8,3 +8,4 @@ dependencies:
     when: etcd_deployment_type == "host"
   - role: docker
     when: (ansible_os_family != "CoreOS" and etcd_deployment_type == "docker")
+  - role: "kubernetes/preinstall"

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -3,7 +3,11 @@ ETCD_ADVERTISE_CLIENT_URLS={{ etcd_client_url }}
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}
 
+{% if not is_etcd_proxy %}
+ETCD_LISTEN_CLIENT_URLS=http://{{ etcd_address }}:2379,http://127.0.0.1:2379
+{% else %}
 ETCD_LISTEN_CLIENT_URLS=http://{{ etcd_address }}:2379
+{% endif %}
 ETCD_ELECTION_TIMEOUT=10000
 ETCD_INITIAL_CLUSTER_TOKEN=k8s_etcd
 ETCD_LISTEN_PEER_URLS=http://{{ etcd_address }}:2380

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -1,16 +1,3 @@
-# This directory is where all the additional scripts go
-# that Kubernetes normally puts in /srv/kubernetes.
-# This puts them in a sane location
-kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
-
-# This directory is where all the additional config stuff goes
-# the kubernetes normally puts in /srv/kubernets.
-# This puts them in a sane location.
-# Editting this value will almost surely break something. Don't
-# change it. Things like the systemd scripts are hard coded to
-# look in here. Don't do it.
-kube_config_dir: /etc/kubernetes
-
 # This is where all the cert scripts and certs will be located
 kube_cert_dir: "{{ kube_config_dir }}/ssl"
 
@@ -19,13 +6,6 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 
 # This is where to save basic auth file
 kube_users_dir: "{{ kube_config_dir }}/users"
-
-# This is where you can drop yaml/json files and the kubelet will run those
-# pods on startup
-kube_manifest_dir: "{{ kube_config_dir }}/manifests"
-
-# Logging directory (sysvinit systems)
-kube_log_dir: "/var/log/kubernetes"
 
 dns_domain: "{{ cluster_name }}"
 

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -1,6 +1,27 @@
 ---
 run_gitinfos: false
 
+# This directory is where all the additional scripts go
+# that Kubernetes normally puts in /srv/kubernetes.
+# This puts them in a sane location
+kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
+
+# This directory is where all the additional config stuff goes
+# the kubernetes normally puts in /srv/kubernets.
+# This puts them in a sane location.
+# Editting this value will almost surely break something. Don't
+# change it. Things like the systemd scripts are hard coded to
+# look in here. Don't do it.
+kube_config_dir: /etc/kubernetes
+
+# Logging directory (sysvinit systems)
+kube_log_dir: "/var/log/kubernetes"
+
+# This is where you can drop yaml/json files and the kubelet will run those
+# pods on startup
+kube_manifest_dir: "{{ kube_config_dir }}/manifests"
+
+
 common_required_pkgs:
   - python-httplib2
   - openssl

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -28,25 +28,28 @@
     path: "{{ kube_config_dir }}"
     state: directory
     owner: kube
+  when: "{{ inventory_hostname in groups['k8s-cluster'] }}"
 
 - name: Create kubernetes script directory
   file:
     path: "{{ kube_script_dir }}"
     state: directory
     owner: kube
+  when: "{{ inventory_hostname in groups['k8s-cluster'] }}"
 
 - name: Create kubernetes manifests directory
   file:
     path: "{{ kube_manifest_dir }}"
     state: directory
     owner: kube
+  when: "{{ inventory_hostname in groups['k8s-cluster'] }}"
 
 - name: Create kubernetes logs directory
   file:
     path: "{{ kube_log_dir }}"
     state: directory
     owner: kube
-  when: ansible_service_mgr in ["sysvinit","upstart"]
+  when: ansible_service_mgr in ["sysvinit","upstart"] and "{{ inventory_hostname in groups['k8s-cluster'] }}"
 
 - name: check cloud_provider value
   fail:
@@ -64,7 +67,7 @@
   with_items:
     - "/etc/cni/net.d"
     - "/opt/cni/bin"
-  when: kube_network_plugin in ["calico", "weave"]
+  when: kube_network_plugin in ["calico", "weave"] and "{{ inventory_hostname in groups['k8s-cluster'] }}"
 
 - name: Update package management cache (YUM)
   yum: update_cache=yes name='*'


### PR DESCRIPTION
etcd facts are generated in kubernetes/preinstall, so etcd nodes need
to be evaluated first before the rest of the deployment.

Moved several directory facts from kubernetes/node to
kubernetes/preinstall because they are not backward dependent.