### PR TITLE
[WIP] Rework systemd service units

### DIFF
--- a/roles/etcd/templates/etcd-docker.service.j2
+++ b/roles/etcd/templates/etcd-docker.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=etcd docker wrapper
-Wants=docker.socket
-After=docker.service
+Wants=docker.service docker.socket
+After=docker.service docker.socket
 
 [Service]
 User=root
@@ -18,7 +18,7 @@ ExecStart={{ docker_bin_dir | default("/usr/bin") }}/docker run --restart=always
 {% if etcd_after_v3 %}
 {{ etcd_container_bin_dir }}etcd
 {% endif %}
-ExecStartPre=-{{ docker_bin_dir | default("/usr/bin") }}/docker rm -f {{ etcd_member_name | default("etcd-proxy") }}
+ExecStopPost=-{{ docker_bin_dir | default("/usr/bin") }}/docker rm -f {{ etcd_member_name | default("etcd-proxy") }}
 ExecReload={{ docker_bin_dir | default("/usr/bin") }}/docker restart {{ etcd_member_name | default("etcd-proxy") }}
 ExecStop={{ docker_bin_dir | default("/usr/bin") }}/docker stop {{ etcd_member_name | default("etcd-proxy") }}
 Restart=always

--- a/roles/etcd/templates/etcd-proxy-docker.service.j2
+++ b/roles/etcd/templates/etcd-proxy-docker.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=etcd-proxy docker wrapper
-Wants=docker.socket
-After=docker.service
+Wants=docker.service docker.socket
+After=docker.service docker.socket
 
 [Service]
 User=root
@@ -18,7 +18,7 @@ ExecStart={{ docker_bin_dir | default("/usr/bin") }}/docker run --restart=always
 {% if etcd_after_v3 %}
 {{ etcd_container_bin_dir }}etcd
 {% endif %}
-ExecStartPre=-{{ docker_bin_dir | default("/usr/bin") }}/docker rm -f {{ etcd_proxy_member_name | default("etcd-proxy") }}
+ExecStopPost=-{{ docker_bin_dir | default("/usr/bin") }}/docker rm -f {{ etcd_proxy_member_name | default("etcd-proxy") }}
 ExecReload={{ docker_bin_dir | default("/usr/bin") }}/docker restart {{ etcd_proxy_member_name | default("etcd-proxy") }}
 ExecStop={{ docker_bin_dir | default("/usr/bin") }}/docker stop {{ etcd_proxy_member_name | default("etcd-proxy") }}
 Restart=always

--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -2,9 +2,11 @@
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 {% if kube_network_plugin is defined and kube_network_plugin == "calico" %}
-After=docker.service calico-node.service
+After=docker.service docker.socket calico-node.service
+Wants=docker.service docker.socket calico-node.service
 {% else %}
-After=docker.service
+After=docker.service docker.socket
+Wants=docker.service docker.socket
 {% endif %}
 
 [Service]
@@ -22,7 +24,7 @@ ExecStart={{ bin_dir }}/kubelet \
 		$KUBELET_REGISTER_NODE \
 		$KUBELET_NETWORK_PLUGIN \
 		$KUBELET_CLOUDPROVIDER
-ExecStartPre=-/usr/bin/docker rm -f kubelet
+ExecStopPost=-/usr/bin/docker rm -f kubelet
 ExecReload=/usr/bin/docker restart kubelet
 Restart=always
 RestartSec=10s

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 Description=Calico per-node agent
 Documentation=https://github.com/projectcalico/calico-docker
-After=docker.service etcd-proxy.service
-Wants=docker.socket
+After=docker.service docker.socket etcd-proxy.service
+Wants=docker.service docker.socket etcd-proxy.service
 
 [Service]
 User=root

--- a/roles/network_plugin/calico/templates/systemd-docker.service
+++ b/roles/network_plugin/calico/templates/systemd-docker.service
@@ -2,11 +2,11 @@
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
-After=network.target
+After=network.target docker-storage-setup.service
 Wants=docker-storage-setup.service
 {% elif ansible_os_family == "Debian" %}
 After=network.target docker.socket
-Requires=docker.socket
+Wants=docker.socket
 {% endif %}
 
 [Service]
@@ -20,6 +20,9 @@ EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/default/docker
 {% endif %}
 Environment=GOTRACEBACK=crash
+ExecReload=/bin/kill -s HUP $MAINPID
+Delegate=yes
+KillMode=process
 ExecStart=/usr/bin/docker daemon \
           $OPTIONS \
           $DOCKER_STORAGE_OPTIONS \

--- a/roles/network_plugin/flannel/templates/systemd-docker.service
+++ b/roles/network_plugin/flannel/templates/systemd-docker.service
@@ -2,22 +2,26 @@
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
-After=network.target
+After=network.target docker-storage-setup.service
 Wants=docker-storage-setup.service
 {% elif ansible_os_family == "Debian" %}
 After=network.target docker.socket
-Requires=docker.socket
+Wants=docker.socket
 {% endif %}
 
 [Service]
 Type=notify
 EnvironmentFile=-/etc/default/docker
 Environment=GOTRACEBACK=crash
+ExecReload=/bin/kill -s HUP $MAINPID
+Delegate=yes
+KillMode=process
 ExecStart=/usr/bin/docker daemon \
           $OPTIONS \
           $DOCKER_STORAGE_OPTIONS \
           $DOCKER_NETWORK_OPTIONS \
-          $INSECURE_REGISTRY
+          $INSECURE_REGISTRY \
+          $DOCKER_OPTS
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity

--- a/roles/network_plugin/weave/templates/systemd-docker.service
+++ b/roles/network_plugin/weave/templates/systemd-docker.service
@@ -6,18 +6,22 @@ After=network.target
 Wants=docker-storage-setup.service
 {% elif ansible_os_family == "Debian" %}
 After=network.target docker.socket
-Requires=docker.socket
+Wants=docker.socket
 {% endif %}
 
 [Service]
 Type=notify
 EnvironmentFile=-/etc/default/docker
 Environment=GOTRACEBACK=crash
+ExecReload=/bin/kill -s HUP $MAINPID
+Delegate=yes
+KillMode=process
 ExecStart=/usr/bin/docker daemon \
           $OPTIONS \
           $DOCKER_STORAGE_OPTIONS \
           $DOCKER_NETWORK_OPTIONS \
-          $INSECURE_REGISTRY
+          $INSECURE_REGISTRY \
+          $DOCKER_OPTS
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity

--- a/roles/network_plugin/weave/templates/weave.service.j2
+++ b/roles/network_plugin/weave/templates/weave.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 Description=Weave Network
 Documentation=http://docs.weave.works/weave/latest_release/
-Requires=docker.service
-After=docker.service
+Wants=docker.service docker.socket
+After=docker.service docker.socket
 
 [Service]
 EnvironmentFile=-/etc/weave.env

--- a/roles/network_plugin/weave/templates/weaveexpose.service.j2
+++ b/roles/network_plugin/weave/templates/weaveexpose.service.j2
@@ -1,9 +1,7 @@
 [Unit]
 Documentation=http://docs.weave.works/
-Requires=docker.service
-Requires=weave.service
-After=weave.service
-After=docker.service
+Wants=docker.service docker.socket weave.service
+After=docker.service docker.socket weave.service
 
 [Service]
 Type=oneshot

--- a/roles/network_plugin/weave/templates/weaveproxy.service.j2
+++ b/roles/network_plugin/weave/templates/weaveproxy.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 Description=Weave proxy for Docker API
 Documentation=http://docs.weave.works/
-Requires=docker.service
-After=docker.service
+Wants=docker.service docker.socket
+After=docker.service docker.socket
 
 [Service]
 EnvironmentFile=-/etc/weave.%H.env


### PR DESCRIPTION
* Add for docker system units:
    ExecReload=/bin/kill -s HUP $MAINPID
    Delegate=yes
    KillMode=process.
* Add missed DOCKER_OPTIONS for calico/weave docker systemd unit.
* Change Requires= to a less strict and non-faily Wants=, add missing
  Wants= for After=.
* Align wants/after in a wat if Wants=foo, After= has foo as well.
* Make wants/after docker.service to ask for the docker.socket as well.
* Move "docker rm -f" commands from ExecStartPre= to ExecStopPost=.
  hooks to ensure non-destructive start attempts issued by Wants=.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>