### PR TITLE
Setup httpredir/tor mirrors for Debian Jessie

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -69,12 +69,18 @@
     - "/opt/cni/bin"
   when: kube_network_plugin in ["calico", "weave"] and "{{ inventory_hostname in groups['k8s-cluster'] }}"
 
+- include: setup_jessie_mirrors.yaml
+  when: ansible_distribution == "Debian" and ansible_distribution_release == "jessie"
+
+- include: update_apt_cache.yaml
+  when: ansible_pkg_mgr == 'apt'
+
 - name: Update package management cache (YUM)
   yum: update_cache=yes name='*'
   when: ansible_pkg_mgr == 'yum'
 
 - name: Install latest version of python-apt for Debian distribs
-  apt: name=python-apt state=latest update_cache=yes cache_valid_time=3600
+  apt: name=python-apt state=latest
   when: ansible_os_family == "Debian"
 
 - name: Install python-dnf for latest RedHat versions

--- a/roles/kubernetes/preinstall/tasks/setup_jessie_mirrors.yaml
+++ b/roles/kubernetes/preinstall/tasks/setup_jessie_mirrors.yaml
@@ -1,0 +1,9 @@
+---
+  - name: install tor transport
+    apt: name=apt-transport-tor
+    when: use_apt_tor
+
+  - name: switch mirrors
+    template:
+      src: apt-repos.j2
+      dest: /etc/apt/sources.list

--- a/roles/kubernetes/preinstall/tasks/update_apt_cache.yaml
+++ b/roles/kubernetes/preinstall/tasks/update_apt_cache.yaml
@@ -1,0 +1,5 @@
+---
+# w/a https://github.com/ansible/ansible-modules-core/issues/2951
+  - name: Update apt cache
+    become: true
+    shell: apt-get update

--- a/roles/kubernetes/preinstall/templates/apt-repos.j2
+++ b/roles/kubernetes/preinstall/templates/apt-repos.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+{% if use_apt_tor %}
+deb tor+http://{{onion_main}}/debian jessie main
+deb tor+http://{{onion_updates}}/debian jessie-updates main
+deb tor+http://{{onion_updates2}}/debian-security jessie/updates main
+{% if use_backports %}deb tor+http://{{onion_backports}}/debian jessie-backports main{% endif %}
+{% else %}
+deb http://httpredir.debian.org/debian jessie main
+deb http://httpredir.debian.org/debian jessie-updates main
+{% if use_backports %}deb http://httpredir.debian.org/debian jessie-backports main{% endif %}
+deb http://security.debian.org jessie/updates main
+{% endif %}

--- a/roles/kubernetes/preinstall/vars/debian.yml
+++ b/roles/kubernetes/preinstall/vars/debian.yml
@@ -3,3 +3,12 @@ required_pkgs:
   - aufs-tools
   - apt-transport-https
   - software-properties-common
+
+use_backports: false
+
+# See https://onion.debian.org and https://onion.torproject.org
+use_apt_tor: false
+onion_main: vwakviie2ienjx6t.onion
+onion_updates: vwakviie2ienjx6t.onion
+onion_updates2: sgvtcaew4bxjd7ln.onion
+onion_backports: vwakviie2ienjx6t.onion


### PR DESCRIPTION
By default use only httpredir mirrors.
Make tor transport configurable as well.

Closes https://github.com/kubespray/kargo/issues/399

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>