### PR TITLE
Check dnsmasq on first kube-node

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -55,7 +55,7 @@
     host: "{{dns_server}}"
     port: 53
     delay: 5
-  when: inventory_hostname == groups['kube-master'][0]
+  when: inventory_hostname == groups['kube-node'][0]
 
 
 - name: check resolvconf


### PR DESCRIPTION
kube-masters without kube-node role will not run
kube-proxy, and therefore can't check if dnsmasq
is running.

Fixes #368