### PR TITLE
Add option to disable ipv6 dns lookup

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -29,6 +29,10 @@ common_required_pkgs:
   - rsync
   - bash-completion
 
+# Set to true if your network does not support IPv6
+# This maybe necessary for pulling Docker images from
+# GCE docker repository
+disable_ipv6_dns: false
 
 
 # For the openstack integration kubelet will need credentials to access

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -97,6 +97,14 @@
   with_items: "{{required_pkgs | default([]) | union(common_required_pkgs|default([]))}}"
   when: ansible_os_family != "CoreOS"
 
+- name: Disable IPv6 DNS lookup
+  lineinfile:
+    dest: /etc/gai.conf
+    line: "precedence ::ffff:0:0/96  100"
+    state: present
+    backup: yes
+  when: disable_ipv6_dns and ansible_os_family != "CoreOS"
+
 # Todo : selinux configuration
 - name: Set selinux policy to permissive
   selinux: policy=targeted state=permissive


### PR DESCRIPTION
New variable disable_ipv6_dns in kubernetes/preinstall. Not disabled by default.