### PR TITLE
Fix resolvconf executable discovery

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -59,13 +59,14 @@
 
 
 - name: check resolvconf
-  stat: path=/etc/resolvconf/resolv.conf.d/head
+  shell: which resolvconf
   register: resolvconf
+  ignore_errors: yes
 
 - name: target resolv.conf file
   set_fact:
     resolvconffile: >-
-      {%- if resolvconf.stat.exists == True -%}/etc/resolvconf/resolv.conf.d/head{%- else -%}/etc/resolv.conf{%- endif -%}
+      {%- if resolvconf.rc == 0 -%}/etc/resolvconf/resolv.conf.d/head{%- else -%}/etc/resolv.conf{%- endif -%}
 
 - name: Add search resolv.conf
   lineinfile:
@@ -109,6 +110,6 @@
 - name: update resolvconf
   command: resolvconf -u
   changed_when: False
-  when: resolvconf.stat.exists == True
+  when: resolvconf.rc == 0
 
 - meta: flush_handlers


### PR DESCRIPTION
If resolvconf was installed and then removed, the file
/etc/resolvconf/resolv.conf.d/head remains in the filesystem

- change discovery of 'resolvconf' executable to check if it
  can be located with 'which resolvconf' command or not.