### PR TITLE
Copy hyperkube cni plugins optionally for calico deployment

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -9,3 +9,8 @@ ipip: false
 # cloud_provider:
 calicoctl_image_repo: calico/ctl
 calicoctl_image_tag: "{{ calico_version }}"
+
+# Set to true if your Hyperkube has all required components to run
+# calico. This is required in order to run canalized calico.
+use_hyperkube_cni: false
+

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -25,10 +25,17 @@
 - name: Calico | Install calico cni bin
   command: rsync -piu "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico"
   changed_when: false
+  when: not use_hyperkube_cni
 
 - name: Calico | Install calico-ipam cni bin
   command: rsync -piu "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico-ipam"
   changed_when: false
+  when: not use_hyperkube_cni
+
+- name: Calico | Copy cni plugins from hyperkube
+  command: "/usr/bin/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -r /opt/cni/bin/. /cnibindir/"
+  changed_when: false
+  when: use_hyperkube_cni
 
 - name: Calico | wait for etcd
   uri: url=http://localhost:2379/health


### PR DESCRIPTION
Hyperkube from CoreOS now ships with all binaries required for
calico and flannel (but not weave). It simplifies deployment for
some network plugin scenarios to not download CNI images.

TODO: Optionally disable downloading calico to /opt/cni/bin