### PR TITLE
Fix etcd play to only run on non-k8s-cluster nodes

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -2,11 +2,11 @@
 - hosts: all
   gather_facts: true
 
-- hosts: etcd
+- hosts: etcd:!k8s-cluster
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
-    - { role: etcd, tags: etcd }
     - { role: docker, tags: docker }
+    - { role: etcd, tags: etcd }
 
 - hosts: k8s-cluster
   roles:


### PR DESCRIPTION
This decreases the time required to deploy a cluster with
3 nodes, but none are standalone etcd roles.