### PR TITLE
Adjust collect-info playbook

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: 'GIT | Install script for collecting git info'
+  template:
+    src: "{{ role_path }}/gen-gitinfos.sh"
+    dest: "{{ bin_dir }}/gen-gitinfos.sh"
+    mode: a+rwx
+
 - include: gitinfos.yml
   when: run_gitinfos
 

--- a/scripts/collect-info.yaml
+++ b/scripts/collect-info.yaml
@@ -7,11 +7,9 @@
     debug: false
     commands:
       - name: git_info
-        cmd: cat {kargo,.}/.git/logs/HEAD
+        cmd: find . -type d -name .git -execdir sh -c 'gen-gitinfos.sh global|head -12' \;
       - name: timedate_info
         cmd: timedatectl status
-      - name: boots_info
-        cmd: journalctl --list-boots --utc --no-pager
       - name: space_info
         cmd: df -h
       - name: kernel_info
@@ -28,10 +26,10 @@
         cmd: ps auxf | grep -v ]$
       - name: systemctl_info
         cmd: systemctl status
+      - name: systemctl_failed_info
+        cmd: systemctl --state=failed --no-pager
       - name: k8s_info
         cmd: kubectl get all --all-namespaces -o wide
-      - name: k8s_dump_info
-        cmd: kubectl get all --all-namespaces -o yaml
       - name: errors_info
         cmd: journalctl -p err --utc --no-pager
 
@@ -43,10 +41,6 @@
       - /var/log/kern.log
       - inventory/inventory.ini
       - cluster.yml
-      - kargo/kargo_default_ubuntu.yaml
-      - kargo/kargo_default_debian.yaml
-      - kargo/kargo_default_common.yaml
-      - kargo/inventory/inventory.cfg
 
   tasks:
     - name: Storing commands output
@@ -68,4 +62,9 @@
       with_items: "{{logs}}"
 
     - name: Pack results and logs
-      local_action: shell GZIP=-9 tar cvzf logs.tar.gz -C /tmp collect-info
+      local_action: shell GZIP=-9 tar --remove-files -cvzf logs.tar.gz -C /tmp collect-info
+      run_once: true
+
+    - name: Clean up collected command outputs
+      file: path={{ item.name }} state=absent
+      with_items: "{{commands}}"


### PR DESCRIPTION
Cleanup collected artifacts,
drop unrelated files/commands.
Always install gitinfos script to binaries for external
use.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>