### PR TITLE
[WIP] Undo fixes to resolvconf and dhclient hooks for rhel

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -114,8 +114,7 @@
   when: ansible_os_family == "Debian"
 
 - name: disable resolv.conf modification by dhclient
-  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/znodnsupdate mode=u+x backup=yes
-  notify: Dnsmasq | restart network
+  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/nodnsupdate mode=u+x backup=yes
   when: ansible_os_family == "RedHat"
 
 - name: update resolvconf


### PR DESCRIPTION
For reasons we're yet to know, the recent fix for dhclient
hooks to the resolvconf works only for debian family. Undo
the fix for rhel family, unless RCA finished and new fix is
submitted.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>