### PR TITLE
[WIP] Rework systemd reload handler

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -4,10 +4,17 @@
   notify:
     - Docker | reload systemd
     - Docker | reload docker
-    - Docker | pause while Docker restarts
     - Docker | wait for docker
 
+# NOTE(bogdando) reloading systemd daemon disturbs docker, we shall wait for it
 - name : Docker | reload systemd
+  command: /bin/true
+  notify:
+    - Docker | systemd-daemon-reload
+    - Docker | wait for docker
+  when: ansible_service_mgr == "systemd"
+
+- name : Docker | systemd-daemon-reload
   shell: systemctl daemon-reload
   when: ansible_service_mgr == "systemd"
 
@@ -15,9 +22,6 @@
   service:
     name: docker
     state: restarted
-
-- name: Docker | pause while Docker restarts
-  pause: seconds=10 prompt="Waiting for docker restart"
 
 - name: Docker | wait for docker
   command: /usr/bin/docker images


### PR DESCRIPTION
When daemon reloaded, it disturbs docker. Wait for docker
when doing systemctl daemon reload. Do that as well to fix
the network_plugin/weave : reload weaveproxy.
Also don't do a 10 sec sleep when restarting docker, instead
rely on the waiter which checks docker via CLI.

Closes: https://github.com/kubespray/kargo/issues/438

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>