### PR TITLE
Fix resolv.conf search/nameserver

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Existing search/nameserver resolvconf entries will be purged and
+# ensured by this additional data:
+
+# Max of 4 names is allowed and no more than 256 - 17 chars total
+# (a 2 is reserved for the 'default.svc.' and'svc.')
+#searchdomains:
+#  - foo.bar.lc
+
+# Max of 2 is allowed here (a 1 is reserved for the dns_server)
+#nameservers:
+#  - 127.0.0.1

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,0 +1,10 @@
+- name: Dnsmasq | restart network
+  service:
+    name: >-
+      {% if ansible_os_family == "RedHat" -%}
+      network
+      {%- elif ansible_os_family == "Debian" -%}
+      networking
+      {%- endif %}
+    state: restarted
+  when: ansible_os_family != "CoreOS"

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -68,9 +68,17 @@
     resolvconffile: >-
       {%- if resolvconf.rc == 0 -%}/etc/resolvconf/resolv.conf.d/head{%- else -%}/etc/resolv.conf{%- endif -%}
 
+- name: generate search domains to resolvconf
+  set_fact:
+    searchentries="{{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}"
+
+- name: generate nameservers to resolvconf
+  set_fact:
+    nameserverentries="{{ nameservers|default([]) + [ dns_server ] }}"
+
 - name: Add search resolv.conf
   lineinfile:
-    line: "search {{ [ 'default.svc.' + dns_domain, 'svc.' + dns_domain, dns_domain ] | join(' ') }}"
+    line: "search {{searchentries}}"
     dest: "{{resolvconffile}}"
     state: present
     insertbefore: BOF
@@ -79,12 +87,13 @@
 
 - name: Add local dnsmasq to resolv.conf
   lineinfile:
-    line: "nameserver {{dns_server}}"
+    line: "nameserver {{item}}"
     dest: "{{resolvconffile}}"
     state: present
     insertafter: "^search.*$"
     backup: yes
     follow: yes
+  with_items: "{{nameserverentries}}"
 
 - name: Add options to resolv.conf
   lineinfile:
@@ -100,11 +109,12 @@
     - attempts:2
 
 - name: disable resolv.conf modification by dhclient
-  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient-enter-hooks.d/nodnsupdate mode=0755 backup=yes
+  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient-enter-hooks.d/znodnsupdate mode=0755
+  notify: Dnsmasq | restart network
   when: ansible_os_family == "Debian"
 
 - name: disable resolv.conf modification by dhclient
-  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/nodnsupdate mode=u+x backup=yes
+  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/nodnsupdate mode=u+x
   when: ansible_os_family == "RedHat"
 
 - name: update resolvconf


### PR DESCRIPTION
Fix resolv.conf search/nameserver

* Ensure additional nameserver/search, if defined as vars.
* Don't backup changed dhclient hooks as they are going to be
  executed by dhclient as well, which is not what we want.
* For debian OS family only:
  * Rename nodnsupdate hook the resolvconf hook to be sourced always
before it.
  * Ensure dhclient restarted via network restart to apply the
nodnsupdate hook.
  * For rhel OS family, the fix TBD, it doesn't work the same way.

Partial https://github.com/kubespray/kargo/issues/322 (only for Debian OS family)