### PR TITLE
Updated kube_version to 1.3.5

### DIFF
--- a/roles/download/vars/kube_versions.yml
+++ b/roles/download/vars/kube_versions.yml
@@ -1,1 +1,1 @@
-kube_version: v1.3.0
+kube_version: v1.3.5

--- a/roles/uploads/vars/kube_versions.yml
+++ b/roles/uploads/vars/kube_versions.yml
@@ -1,1 +1,1 @@
-kube_version: v1.3.0
+kube_version: v1.3.5


### PR DESCRIPTION
Changed use_cni_hyperkube to true because the new
CoreOS hyperkube has calico baked in.