### PR TITLE
Refactor roles and hosts

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -5,19 +5,18 @@
 - hosts: etcd:!k8s-cluster
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
-    - { role: docker, tags: docker }
     - { role: etcd, tags: etcd }
 
 - hosts: k8s-cluster
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
-    - { role: docker, tags: docker }
     - { role: etcd, tags: etcd }
     - { role: kubernetes/node, tags: node }
     - { role: network_plugin, tags: network }
 
 - hosts: kube-master
   roles:
+    - { role: kubernetes/preinstall, tags: preinstall }
     - { role: kubernetes/master, tags: master }
 
 - hosts: k8s-cluster

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -7,5 +7,4 @@ dependencies:
     file: "{{ downloads.etcd }}"
     when: etcd_deployment_type == "host"
   - role: docker
-    when: (ansible_os_family != "CoreOS" and etcd_deployment_type == "docker")
-  - role: "kubernetes/preinstall"
+    when: (ansible_os_family != "CoreOS" and etcd_deployment_type == "docker" or inventory_hostname in groups['k8s-cluster'])

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -1,0 +1,15 @@
+# This is where all the cert scripts and certs will be located
+kube_cert_dir: "{{ kube_config_dir }}/ssl"
+
+# This is where all of the bearer tokens will be stored
+kube_token_dir: "{{ kube_config_dir }}/tokens"
+
+# This is where to save basic auth file
+kube_users_dir: "{{ kube_config_dir }}/users"
+
+# An experimental dev/test only dynamic volumes provisioner,
+# for PetSets. Works for kube>=v1.3 only.
+kube_hostpath_dynamic_provisioner: "false"
+
+hyperkube_image_repo: "quay.io/coreos/hyperkube"
+hyperkube_image_tag: "{{ kube_version }}_coreos.0"

--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -2,8 +2,8 @@
 - name: Master | restart kubelet
   command: /bin/true
   notify:
-    - Kubelet | reload systemd
-    - Kubelet | reload kubelet
+    - Master | reload systemd
+    - Master | reload kubelet
 
 - name: wait for master static pods
   command: /bin/true

--- a/roles/kubernetes/master/meta/main.yml
+++ b/roles/kubernetes/master/meta/main.yml
@@ -2,5 +2,3 @@
 dependencies:
   - role: download # For kube_version variable
     file: "{{ downloads.nothing }}"
-  - { role: etcd }
-  - { role: kubernetes/node }

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -1,22 +1,12 @@
 # This is where all the cert scripts and certs will be located
 kube_cert_dir: "{{ kube_config_dir }}/ssl"
 
-# This is where all of the bearer tokens will be stored
-kube_token_dir: "{{ kube_config_dir }}/tokens"
-
-# This is where to save basic auth file
-kube_users_dir: "{{ kube_config_dir }}/users"
-
 dns_domain: "{{ cluster_name }}"
 
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
 
 kube_proxy_mode: iptables
-
-# An experimental dev/test only dynamic volumes provisioner,
-# for PetSets. Works for kube>=v1.3 only.
-kube_hostpath_dynamic_provisioner: "false"
 
 hyperkube_image_repo: "quay.io/coreos/hyperkube"
 hyperkube_image_tag: "{{ kube_version }}_coreos.0"

--- a/roles/kubernetes/secrets/defaults/main.yml
+++ b/roles/kubernetes/secrets/defaults/main.yml
@@ -1,0 +1,8 @@
+# This is where all the cert scripts and certs will be located
+kube_cert_dir: "{{ kube_config_dir }}/ssl"
+
+# This is where all of the bearer tokens will be stored
+kube_token_dir: "{{ kube_config_dir }}/tokens"
+
+# This is where to save basic auth file
+kube_users_dir: "{{ kube_config_dir }}/users"

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -6,4 +6,3 @@ dependencies:
    when: kube_network_plugin == 'flannel'
  - role: network_plugin/weave
    when: kube_network_plugin == 'weave'
- - role: docker


### PR DESCRIPTION
Shorten deployment time with:
- Remove redundand roles if duplicated by a dependency and vice versa
- When a member of k8s-cluster, always install docker as a dependency
  of the etcd role and drop the docker role from cluster.yaml.
- Drop etcd and node role dependencies from master role as they are
  covered by the node role in k8s-cluster group as well.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>