### PR TITLE
Enable customization of calico-node docker image

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -7,8 +7,12 @@ ipip: false
 
 # cloud_provider can only be set to 'gce' or 'aws'
 # cloud_provider:
+
 calicoctl_image_repo: calico/ctl
 calicoctl_image_tag: "{{ calico_version }}"
+
+calico_node_image_repo: calico/node
+calico_node_image_tag: "{{ calico_version }}"
 
 # Set to true if your Hyperkube has all required components to run
 # calico. This is required in order to run canalized calico.

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -8,9 +8,9 @@ Wants=docker.socket etcd-proxy.service
 User=root
 PermissionsStartOnly=true
 {% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
-ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --detach=false
+ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
 {%     else %}
-ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --detach=false
+ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
 {%     endif %}
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
New vars: calico_node_image_repo and calico_node_image_tag
Defaults: calico/node and {{ calico_version }}, respectively