### PR TITLE
[WIP] Fix networking restart

### DIFF
--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,10 +1,14 @@
-- name: Dnsmasq | restart network
-  service:
-    name: >-
-      {% if ansible_os_family == "RedHat" -%}
-      network
-      {%- elif ansible_os_family == "Debian" -%}
-      networking
-      {%- endif %}
-    state: restarted
+- name: Dnsmasq | apply resolvconf
+  command: /bin/true
+  notify:
+    - Dnsmasq | kill dhclient
+    - Dnsmasq | update resolvconf
   when: ansible_os_family != "CoreOS"
+
+- name: Dnsmasq | kill dhclient
+  shell: kill -11 $(pidof dhclient)
+  ignore_errors: true
+
+- name: Dnsmasq | update resolvconf
+  command: resolvconf -u
+  ignore_errors: true

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -110,16 +110,10 @@
 
 - name: disable resolv.conf modification by dhclient
   copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient-enter-hooks.d/znodnsupdate mode=0755
-  notify: Dnsmasq | restart network
+  notify: Dnsmasq | apply resolvconf
   when: ansible_os_family == "Debian"
 
 - name: disable resolv.conf modification by dhclient
-  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/nodnsupdate mode=u+x
+  copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/znodnsupdate mode=u+x
+  notify: Dnsmasq | apply resolvconf
   when: ansible_os_family == "RedHat"
-
-- name: update resolvconf
-  command: resolvconf -u
-  changed_when: False
-  when: resolvconf.rc == 0
-
-- meta: flush_handlers


### PR DESCRIPTION
In order to apply dhclient hooks, drop network restarting as it is a too
heavy operation and may sometimes hang as well. Instead, kill dhclient
then refresh resolvconf. This postpones application of changes to
dhclient conf and hooks unless it is restarted, eventually.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>