### PR TITLE
Fix vagrant custom instance name prefix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,11 +100,11 @@ Vagrant.configure("2") do |config|
           #ansible.tags = ['download']
           ansible.groups = {
             # The first three nodes should be etcd servers
-            "etcd" => ["k8s-0[1:3]"],
+            "etcd" => ["#{$instance_name_prefix}-0[1:3]"],
             # The first two nodes should be masters
-            "kube-master" => ["k8s-0[1:2]"],
+            "kube-master" => ["#{$instance_name_prefix}-0[1:2]"],
             # all nodes should be kube nodes
-            "kube-node" => ["k8s-0[1:#{$num_instances}]"],
+            "kube-node" => ["#{$instance_name_prefix}-0[1:#{$num_instances}]"],
             "k8s-cluster:children" => ["kube-master", "kube-node"],
           }
         end


### PR DESCRIPTION
This PR fixes one issue in Vagrantfile. There is a global variable `$instance_name_prefix` which is used to define virtual machine names. But when vagrant generates ansible inventory file for vagrant it is use hardcoded name `k8s`. This is how it looks:

```ini
# Generated by Vagrant

custom-name-03 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2201 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/s1/.vagrant.d/insecure_private_key' ip=172.17.8.103 flannel_interface=172.17.8.103 flannel_backend_type=host-gw local_release_dir=/vagrant/temp download_run_once=True
custom-name-02 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2200 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/s1/.vagrant.d/insecure_private_key' ip=172.17.8.102 flannel_interface=172.17.8.102 flannel_backend_type=host-gw local_release_dir=/vagrant/temp download_run_once=True
custom-name-01 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/s1/.vagrant.d/insecure_private_key' ip=172.17.8.101 flannel_interface=172.17.8.101 flannel_backend_type=host-gw local_release_dir=/vagrant/temp download_run_once=True

[etcd]
k8s-0[1:3]

[kube-master]
k8s-0[1:2]

[kube-node]
k8s-0[1:3]

[k8s-cluster:children]
kube-master
kube-node
```

This is inventory file with this fix:
```ini
# Generated by Vagrant

custom-name-03 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2201 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/s1/.vagrant.d/insecure_private_key' ip=172.17.8.103 flannel_interface=172.17.8.103 flannel_backend_type=host-gw local_release_dir=/vagrant/temp download_run_once=True
custom-name-02 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2200 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/s1/.vagrant.d/insecure_private_key' ip=172.17.8.102 flannel_interface=172.17.8.102 flannel_backend_type=host-gw local_release_dir=/vagrant/temp download_run_once=True
custom-name-01 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/s1/.vagrant.d/insecure_private_key' ip=172.17.8.101 flannel_interface=172.17.8.101 flannel_backend_type=host-gw local_release_dir=/vagrant/temp download_run_once=True

[etcd]
custom-name-0[1:3]

[kube-master]
custom-name-0[1:2]

[kube-node]
custom-name-0[1:3]

[k8s-cluster:children]
kube-master
kube-node
```