### PR TITLE
Issue 369

### DIFF
--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -42,12 +42,14 @@
     mode: 0644
   notify:
     - restart docker
+  when: ansible_os_family != "CoreOS"
 
-- name: Flannel | Create docker config symlink for CoreOS
-  file:
-    src: "/etc/default/docker"
-    dest: "/run/flannel_docker_opts.env"
-    state: link
+- name: Flannel | Create docker dropin for CoreOS
+  template:
+    src: docker-dropin
+    dest: "/etc/systemd/system/docker.service.d/flannel-options.conf"
+  notify:
+    - restart docker
   when: ansible_os_family == "CoreOS"
 
 - meta: flush_handlers

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Flannel | Create docker dropin for CoreOS
   template:
-    src: docker-dropin
+    src: docker-systemd
     dest: "/etc/systemd/system/docker.service.d/flannel-options.conf"
   notify:
     - restart docker

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -44,6 +44,10 @@
     - restart docker
   when: ansible_os_family != "CoreOS"
 
+- name: Flannel | Create docker service path for CoreOS
+  file: path=/etc/systemd/system/docker.service.d state=directory
+  when: ansible_os_family == "CoreOS"
+
 - name: Flannel | Create docker dropin for CoreOS
   template:
     src: docker-systemd

--- a/roles/network_plugin/flannel/templates/docker-systemd
+++ b/roles/network_plugin/flannel/templates/docker-systemd
@@ -1,0 +1,2 @@
+[Service]
+Environment="DOCKER_OPTS=--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"


### PR DESCRIPTION
This PR will lay down a docker drop-in for flannel environment variables, instead of creating a symlink at /run/flannel_docker_opts.env. This appears to function as expected in terms of the flannel options persisting reboot and being available as docker comes online. I believe the underlying issue is that the /run path is a tmpfs in CoreOS and thus disappears at restart.

In the future, it may very well be that we can also leverage this dropin template for all docker options, as it should work for all systemd OSes.

Fixes #369 