### PR TITLE
Disable calicoctl from creating a default pool

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -73,6 +73,8 @@
 
 - name: Calico | Configure calico network pool {{ pool_task_name|default('') }}
   command: "{{ bin_dir}}/calicoctl pool add {{ kube_pods_subnet }} {{ ipip_arg|default('') }} {{ nat_arg|default('') }}"
+  environment:
+    NO_DEFAULT_POOLS: true
   run_once: true
   when: calico_conf.status == 404
 


### PR DESCRIPTION
Sometimes invoking calicoctl to create a pool also
creates a default pool, which causes errors in deploy.