### PR TITLE
Fix updating resolvconf

### DIFF
--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,4 +1,11 @@
 - name: Dnsmasq | restart network
+  command: /bin/true
+  notify:
+    - Dnsmasq | reload network
+    - Dnsmasq | update resolvconf
+  when: ansible_os_family != "CoreOS"
+
+- name: Dnsmasq | reload network
   service:
     name: >-
       {% if ansible_os_family == "RedHat" -%}
@@ -7,4 +14,8 @@
       networking
       {%- endif %}
     state: restarted
-  when: ansible_os_family != "CoreOS"
+  when: ansible_os_family != "RedHat" and ansible_os_family != "CoreOS"
+
+- name: Dnsmasq | update resolvconf
+  command: /sbin/resolvconf -u
+  ignore_errors: true

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -127,11 +127,5 @@
 
 - name: disable resolv.conf modification by dhclient
   copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/nodnsupdate mode=u+x
+  notify: Dnsmasq | restart network
   when: ansible_os_family == "RedHat"
-
-- name: update resolvconf
-  command: resolvconf -u
-  changed_when: False
-  when: resolvconf.rc == 0
-
-- meta: flush_handlers


### PR DESCRIPTION
Move updating resolvconf to the network restart handler to
ensure changes applied to the /etc/resolv.conf.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>