### PR TITLE
Rename kube-dns back to kubedns

### DIFF
--- a/roles/kubernetes-apps/templates/kubedns-rc.yml
+++ b/roles/kubernetes-apps/templates/kubedns-rc.yml
@@ -4,7 +4,7 @@ metadata:
   name: kube-dns-v19
   namespace: kube-system
   labels:
-    k8s-app: kube-dns
+    k8s-app: kubedns
     version: v19
     kubernetes.io/cluster-service: "true"
 spec:

--- a/roles/kubernetes-apps/templates/kubedns-svc.yml
+++ b/roles/kubernetes-apps/templates/kubedns-svc.yml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-dns
+  name: kubedns
   namespace: kube-system
   labels:
-    k8s-app: kube-dns
+    k8s-app: kubedns
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "KubeDNS"
+    kubernetes.io/name: "kubedns"
 spec:
   selector:
-    k8s-app: kube-dns
+    k8s-app: kubedns
   clusterIP: {{ skydns_server }}
   ports:
   - name: dns


### PR DESCRIPTION
kubedns should stay named the same so that services which
depend on this name are not broken.