### PR TITLE
Reset replicacluster name of kube-dns-v19 back to kubedns

### DIFF
--- a/roles/kubernetes-apps/templates/kubedns-rc.yml
+++ b/roles/kubernetes-apps/templates/kubedns-rc.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v19
+  name: kubedns
   namespace: kube-system
   labels:
     k8s-app: kubedns
@@ -10,12 +10,12 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-dns
+    k8s-app: kubedns
     version: v19
   template:
     metadata:
       labels:
-        k8s-app: kube-dns
+        k8s-app: kubedns
         version: v19
         kubernetes.io/cluster-service: "true"
     spec:


### PR DESCRIPTION
This broke upgraded clusters