### PR TITLE
Check kube version for calico cni to use

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -13,8 +13,3 @@ calicoctl_image_tag: "{{ calico_version }}"
 
 calico_node_image_repo: calico/node
 calico_node_image_tag: "{{ calico_version }}"
-
-# Set to true if your Hyperkube has all required components to run
-# calico. This is required in order to run canalized calico.
-use_hyperkube_cni: false
-

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -22,6 +22,17 @@
   changed_when: false
   notify: restart calico-node
 
+- name: Calico | Determine hyperkube cni to use depending of the version of kube
+  set_fact:
+    use_hyperkube_cni: >
+      {%- if kube_version | version_compare('v1.3.4','>=') -%}
+        true
+      {%- elif kube_version | version_compare('v1.3.4','<') -%}
+        false
+      {%- else -%}
+        {{ ErrorCannotRecognizeVersion }}
+      {%- endif -%}
+
 - name: Calico | Install calico cni bin
   command: rsync -piu "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico"
   changed_when: false


### PR DESCRIPTION
Starting from version 1.3.4 of hyperkube, calico is "canalized" which requires flannel and hostonly cni plugins.