### PR TITLE
Fix reverse DNS lookups of service IPs.

### DIFF
--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -4,8 +4,6 @@ listen-address=0.0.0.0
 
 addn-hosts=/etc/hosts
 
-bogus-priv
-
 #Set upstream dns servers
 {% if upstream_dns_servers is defined %}
 {% for srv in upstream_dns_servers %}
@@ -18,3 +16,6 @@ server={{ srv }}
 
 # Forward k8s domain to kube-dns
 server=/{{ dns_domain }}/{{ skydns_server }}
+
+# Forward reverse lookups for k8s service addresses to kube-dns
+rev-server={{ kube_service_addresses }},{{ skydns_server }}


### PR DESCRIPTION
This fixes "DNS should provide DNS for services [Conformance]"
e2e test in k8s.