### PR TITLE
Restored gather facts on all hosts

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -6,14 +6,16 @@
   tags:
     - bootstrap-os
 
-- hosts: etcd:!k8s-cluster
+
+- hosts: all
   gather_facts: true
+
+- hosts: etcd:!k8s-cluster
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: etcd, tags: etcd }
 
 - hosts: k8s-cluster
-  gather_facts: true
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: etcd, tags: etcd }
@@ -21,17 +23,14 @@
     - { role: network_plugin, tags: network }
 
 - hosts: kube-master
-  gather_facts: true
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: kubernetes/master, tags: master }
 
 - hosts: k8s-cluster
-  gather_facts: true
   roles:
     - { role: dnsmasq, tags: dnsmasq }
 
 - hosts: kube-master[0]
-  gather_facts: true
   roles:
     - { role: kubernetes-apps, tags: apps }


### PR DESCRIPTION
Gathering facts on all hosts was removed in a previous commit: 2606e8e1c8a18b6b813f12d1ea5c8c5a6d2f2aa0

This broke some of the preinstall automation, because that playbook refers to hosts/groups (eg kube-master) that haven't had facts gathered on them yet.
Example: https://github.com/kubespray/kargo/blob/master/roles/kubernetes/preinstall/tasks/set_facts.yml#L6

This pull request restores gathering facts on all hosts before continuing. 