### PR TITLE
Fix delegate_to expression in download tasks

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Create dest directories
   file: path={{local_release_dir}}/{{download.dest|dirname}} state=directory recurse=yes
   when: "{{ download.enabled|bool and not download.container|bool }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else omit }}"
+  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
   run_once: "{{ download_run_once|bool }}"
 
 - name: Download items
@@ -24,7 +24,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when: "{{ download.enabled|bool and not download.container|bool }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else omit }}"
+  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
   run_once: "{{ download_run_once|bool }}"
 
 - name: Extract archives
@@ -35,7 +35,7 @@
     mode: "{{ download.mode|default(omit) }}"
     copy: no
   when: "{{ download.enabled|bool and not download.container|bool and download.unarchive is defined and download.unarchive == True }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else omit }}"
+  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
   run_once: "{{ download_run_once|bool }}"
 
 - name: Fix permissions
@@ -45,7 +45,7 @@
     owner: "{{ download.owner|default(omit) }}"
     mode: "{{ download.mode|default(omit) }}"
   when: "{{ download.enabled|bool and not download.container|bool and (download.unarchive is not defined or download.unarchive == False) }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else omit }}"
+  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
   run_once: "{{ download_run_once|bool }}"
 
 - name: pulling...
@@ -65,7 +65,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when: "{{ download.enabled|bool and download.container|bool }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else omit }}"
+  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
   run_once: "{{ download_run_once|bool }}"
 
 - set_fact:


### PR DESCRIPTION
Fix delegate_to expression in download tasks
  
"else omit" is causing problems in this expression. Replacing it with more strict "inventory_hostname" fixes the issue and handles `download_run_once` as expected.

Closes issue #514
