### PR TITLE
Move kube_version var to defaults

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -5,7 +5,7 @@ local_release_dir: /tmp
 download_run_once: False
 
 # Versions
-include_vars: kube_versions.yml
+kube_version: v1.3.0
 
 etcd_version: v3.0.6
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- include_vars: kube_versions.yml
-
 - name: downloading...
   debug:
     msg: "{{ download.url }}"

--- a/roles/download/vars/kube_versions.yml
+++ b/roles/download/vars/kube_versions.yml
@@ -1,1 +1,0 @@
-kube_version: v1.3.0

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -2,7 +2,7 @@
 local_release_dir: /tmp
 
 # Versions
-include_vars: kube_versions.yml
+kube_version: v1.3.0
 
 etcd_version: v3.0.6
 calico_version: v0.20.0

--- a/roles/uploads/tasks/main.yml
+++ b/roles/uploads/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- include_vars: "kube_versions.yml"
-
 - name: Create dest directories
   file: path={{local_release_dir}}/{{item.dest|dirname}} state=directory recurse=yes
   with_items: '{{downloads}}'

--- a/roles/uploads/vars/kube_versions.yml
+++ b/roles/uploads/vars/kube_versions.yml
@@ -1,1 +1,0 @@
-kube_version: v1.3.0


### PR DESCRIPTION
Move the variable kube_version to defaults to have the possibility to overwrite it via group_vars inventory if needed.