### PR TITLE
Skip download_run_once for binaries as unimplemented yet

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -9,8 +9,6 @@
 - name: Create dest directories
   file: path={{local_release_dir}}/{{download.dest|dirname}} state=directory recurse=yes
   when: "{{ download.enabled|bool and not download.container|bool }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
-  run_once: "{{ download_run_once|bool }}"
 
 - name: Download items
   get_url:
@@ -24,8 +22,6 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when: "{{ download.enabled|bool and not download.container|bool }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
-  run_once: "{{ download_run_once|bool }}"
 
 - name: Extract archives
   unarchive:
@@ -35,8 +31,6 @@
     mode: "{{ download.mode|default(omit) }}"
     copy: no
   when: "{{ download.enabled|bool and not download.container|bool and download.unarchive is defined and download.unarchive == True }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
-  run_once: "{{ download_run_once|bool }}"
 
 - name: Fix permissions
   file:
@@ -45,8 +39,6 @@
     owner: "{{ download.owner|default(omit) }}"
     mode: "{{ download.mode|default(omit) }}"
   when: "{{ download.enabled|bool and not download.container|bool and (download.unarchive is not defined or download.unarchive == False) }}"
-  delegate_to: "{{ groups['kube-master'][0] if download_run_once|bool else inventory_hostname }}"
-  run_once: "{{ download_run_once|bool }}"
 
 - name: pulling...
   debug:


### PR DESCRIPTION
Disable the download_run_once for binaries as it is not implemented anyway, yet.

Partial fix to https://github.com/kubespray/kargo/issues/526

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>