### PR TITLE
Add support for --masquerade-all in kube-proxy

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -8,6 +8,9 @@ kube_resolv_conf: "/etc/resolv.conf"
 
 kube_proxy_mode: iptables
 
+# If using the pure iptables proxy, SNAT everything
+kube_proxy_masquerade_all: true
+
 # kube_api_runtime_config:
 #   - extensions/v1beta1/daemonsets=true
 #   - extensions/v1beta1/deployments=true

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -18,6 +18,9 @@ spec:
 {% endif %}
     - --bind-address={{ ip | default(ansible_default_ipv4.address) }}
     - --proxy-mode={{ kube_proxy_mode }}
+{% if kube_proxy_masquerade_all and kube_proxy_mode == "iptables" %}
+    - --masquerade-all
+{% endif %}
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
New boolean var `kube_proxy_masquerade_all` which enables/disables
`--masquerade-all` argument for kube-proxy.

Closes #524