### PR TITLE
Disable reverse lookups again

### DIFF
--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -18,6 +18,7 @@ server={{ srv }}
  server=8.8.4.4
 {% endif %}
 
+bogus-priv
 no-resolv
 no-negcache
 cache-size=1000


### PR DESCRIPTION
Initially this was removed, but it turns out that services that
perform reverse lookups (such as MariaDB) will encounter severe
performance degredation with this disabled.