### PR TITLE
Bump Calico-CNI-plugin version to 1.4.2

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -11,7 +11,7 @@ etcd_version: v3.0.6
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
 calico_version: v0.20.0
-calico_cni_version: v1.3.1
+calico_cni_version: v1.4.2
 weave_version: v1.6.1
 flannel_version: 0.5.5
 flannel_server_helper_version: 0.1
@@ -23,8 +23,8 @@ calico_cni_ipam_download_url: "https://storage.googleapis.com/kargo/{{calico_cni
 weave_download_url: "https://storage.googleapis.com/kargo/{{weave_version}}_weave"
 
 # Checksums
-calico_cni_checksum: "ac05cb9254b5aaa5822cf10325983431bd25489147f2edf9dec7e43d99c43e77"
-calico_cni_ipam_checksum: "3df6951a30749c279229e7e318e74ac4e41263996125be65257db7cd25097273"
+calico_cni_checksum: "9cab29764681e9d80da826e4b2cd10841cc01a749e0018867d96dd76a4691548"
+calico_cni_ipam_checksum: "09d076b15b791956efee91646e47fdfdcf382db16082cef4f542a9fff7bae172"
 weave_checksum: "9bf9d6e5a839e7bcbb28cc00c7acae9d09284faa3e7a3720ca9c2b9e93c68580"
 etcd_checksum: "385afd518f93e3005510b7aaa04d38ee4a39f06f5152cd33bb86d4f0c94c7485"
 

--- a/roles/kubernetes/node/templates/cni-calico.conf.j2
+++ b/roles/kubernetes/node/templates/cni-calico.conf.j2
@@ -1,9 +1,11 @@
 {
   "name": "calico-k8s-network",
   "type": "calico",
-  "etcd_authority": "{{ etcd_authority }}",
   "log_level": "info",
   "ipam": {
     "type": "calico-ipam"
+  },
+  "kubernetes": {
+    "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
   }
 }

--- a/roles/kubernetes/node/templates/node-kubeconfig.yaml.j2
+++ b/roles/kubernetes/node/templates/node-kubeconfig.yaml.j2
@@ -4,7 +4,7 @@ clusters:
 - name: local
   cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.pem
-    server: http://127.0.0.1:8080
+    server: {{ kube_apiserver_endpoint }}
 users:
 - name: kubelet
   user:

--- a/roles/kubernetes/node/templates/node-kubeconfig.yaml.j2
+++ b/roles/kubernetes/node/templates/node-kubeconfig.yaml.j2
@@ -4,6 +4,7 @@ clusters:
 - name: local
   cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: http://127.0.0.1:8080
 users:
 - name: kubelet
   user:

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -6,7 +6,7 @@ kube_version: v1.3.0
 
 etcd_version: v3.0.6
 calico_version: v0.20.0
-calico_cni_version: v1.3.1
+calico_cni_version: v1.4.2
 weave_version: v1.6.1
 
 # Download URL's
@@ -16,8 +16,8 @@ calico_cni_ipam_download_url: "https://github.com/projectcalico/calico-cni/relea
 weave_download_url: "https://github.com/weaveworks/weave/releases/download/{{weave_version}}/weave"
 
 # Checksums
-calico_cni_checksum: "ac05cb9254b5aaa5822cf10325983431bd25489147f2edf9dec7e43d99c43e77"
-calico_cni_ipam_checksum: "3df6951a30749c279229e7e318e74ac4e41263996125be65257db7cd25097273"
+calico_cni_checksum: "9cab29764681e9d80da826e4b2cd10841cc01a749e0018867d96dd76a4691548"
+calico_cni_ipam_checksum: "09d076b15b791956efee91646e47fdfdcf382db16082cef4f542a9fff7bae172"
 weave_checksum: "9bf9d6e5a839e7bcbb28cc00c7acae9d09284faa3e7a3720ca9c2b9e93c68580"
 etcd_checksum: "385afd518f93e3005510b7aaa04d38ee4a39f06f5152cd33bb86d4f0c94c7485"
 


### PR DESCRIPTION
This patch contains:

* required changes on Kubernetes and CNI config files
* Version and checksum correction

Closes: #535