### PR TITLE
Upgrade to kubernetes version 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you have questions, you can [invite yourself](https://slack.kubespray.io/) to
 
 To deploy the cluster you can use :
 
-[**kargo-cli**](https://github.com/kubespray/kargo-cli) <br>
+[**kargo-cli**](https://github.com/kubespray/kargo-cli) (deprecated, a newer [go](https://github.com/Smana/kargo-cli/tree/kargogo) version soon)<br>
 **Ansible** usual commands <br>
 **vagrant** by simply running `vagrant up` (for tests purposes) <br>
 
@@ -41,7 +41,7 @@ Supported Linux distributions
 Versions
 --------------
 
-[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.3.0 <br>
+[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.4.0 <br>
 [etcd](https://github.com/coreos/etcd/releases) v3.0.1 <br>
 [calicoctl](https://github.com/projectcalico/calico-docker/releases) v0.20.0 <br>
 [flanneld](https://github.com/coreos/flannel/releases) v0.5.5 <br>

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -109,9 +109,9 @@ kube_apiserver_insecure_port: 8080 # (http)
 # Do not install additional dnsmasq
 skip_dnsmasq: false
 # Upstream dns servers used by dnsmasq
-upstream_dns_servers:
-  - 8.8.8.8
-  - 8.8.4.4
+#upstream_dns_servers:
+#  - 8.8.8.8
+#  - 8.8.4.4
 #
 # # Use dns server : https://github.com/ansibl8s/k8s-skydns/blob/master/skydns-README.md
 dns_setup: true

--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -13,6 +13,8 @@ server=/{{ dns_domain }}/{{ skydns_server }}
 {% for srv in upstream_dns_servers %}
 server={{ srv }}
 {% endfor %}
+{% elif cloud_provider == "gce" %}
+server=169.254.169.254
 {% else %}
  server=8.8.8.8
  server=8.8.4.4

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -5,7 +5,7 @@ local_release_dir: /tmp
 download_run_once: False
 
 # Versions
-kube_version: v1.3.0
+kube_version: v1.4.0
 
 etcd_version: v3.0.6
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -7,4 +7,4 @@ ipip: false
 
 # Set to true if you want your calico cni binaries to overwrite the
 # ones from hyperkube while leaving other cni plugins intact.
-overwrite_hyperkube_cni: false
+overwrite_hyperkube_cni: true

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -22,16 +22,6 @@
   changed_when: false
   notify: restart calico-node
 
-- name: Calico | Do not use hyperkube cni if kube_version under v1.3.4
-  set_fact:
-    use_hyperkube_cni: false
-  when: kube_version | version_compare('v1.3.4','<')
-
-- name: Calico | Use hyperkube cni if kube_version above v1.3.4
-  set_fact:
-    use_hyperkube_cni: true
-  when: kube_version | version_compare('v1.3.4','>=')
-
 - name: Calico | Copy cni plugins from hyperkube
   command: "/usr/bin/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /usr/bin/rsync -a /opt/cni/bin/ /cnibindir/"
   register: cni_task_result
@@ -39,17 +29,16 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
-  when: "{{ use_hyperkube_cni|bool }}"
 
 - name: Calico | Install calico cni bin
   command: rsync -pi "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico"
   changed_when: false
-  when: "{{ not use_hyperkube_cni|bool or overwrite_hyperkube_cni|bool }}"
+  when: "{{ overwrite_hyperkube_cni|bool }}"
 
 - name: Calico | Install calico-ipam cni bin
   command: rsync -pi "{{ local_release_dir }}/calico/bin/calico-ipam" "/opt/cni/bin/calico-ipam"
   changed_when: false
-  when: "{{ not use_hyperkube_cni|bool or overwrite_hyperkube_cni|bool }}"
+  when: "{{ overwrite_hyperkube_cni|bool }}"
 
 - name: Calico | wait for etcd
   uri: url=http://localhost:2379/health

--- a/roles/network_plugin/weave/tasks/main.yml
+++ b/roles/network_plugin/weave/tasks/main.yml
@@ -9,17 +9,6 @@
   notify:
     - restart docker
 
-- name: Weave | Determine hyperkube cni to use depending of the version of kube
-  set_fact:
-    use_hyperkube_cni: >
-      {%- if kube_version | version_compare('v1.3.4','>=') -%}
-        true
-      {%- elif kube_version | version_compare('v1.3.4','<') -%}
-        false
-      {%- else -%}
-        {{ ErrorCannotRecognizeVersion }}
-      {%- endif -%}
-
 - name: Weave | Copy cni plugins from hyperkube
   command: "/usr/bin/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -r /opt/cni/bin/. /cnibindir/"
   register: cni_task_result
@@ -27,7 +16,6 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
-  when: "{{ use_hyperkube_cni|bool }}"
 
 - name: Weave | Install weave
   command: rsync -piu "{{ local_release_dir }}/weave/bin/weave" "{{ bin_dir }}/weave"

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -2,7 +2,7 @@
 local_release_dir: /tmp
 
 # Versions
-kube_version: v1.3.0
+kube_version: v1.4.0
 
 etcd_version: v3.0.6
 calico_version: v0.20.0


### PR DESCRIPTION
The cni plugins are not in the hyperkube image so it is required to use the downloaded binaries.
We need to use Google's dns server otherwise kubelet won't start properly