### PR TITLE
Add default GCE hardcoded nameservers

### DIFF
--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -10,12 +10,14 @@ server=/{{ dns_domain }}/{{ skydns_server }}
 
 #Set upstream dns servers
 {% if upstream_dns_servers is defined %}
-{% for srv in upstream_dns_servers %}
+{%   for srv in upstream_dns_servers %}
 server={{ srv }}
-{% endfor %}
+{%   endfor %}
+{% elif cloud_provider == "gce" %}
+server=169.254.169.254
 {% else %}
- server=8.8.8.8
- server=8.8.4.4
+server=8.8.8.8
+server=8.8.4.4
 {% endif %}
 
 bogus-priv


### PR DESCRIPTION
Used only when cloud_provider=gce