### PR TITLE
Add possibility to enable network policy via Calico network controller

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/calico-policy-controller.yml
+++ b/roles/kubernetes-apps/ansible/tasks/calico-policy-controller.yml
@@ -1,0 +1,10 @@
+- name: Write calico-policy-controller yaml
+  template: src=calico-policy-controller.yml.j2 dest=/etc/kubernetes/calico-policy-controller.yml
+  when: inventory_hostname == groups['kube-master'][0]
+
+
+- name: Start of Calico policy controller
+  kube:
+    kubectl: "{{bin_dir}}/kubectl"
+    filename: /etc/kubernetes/calico-policy-controller.yml
+  when: inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/ansible/tasks/main.yaml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yaml
@@ -17,3 +17,7 @@
     state: "{{item.changed | ternary('latest','present') }}"
   with_items: "{{ manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0]
+
+
+- include: tasks/calico-policy-controller.yml
+  when: enable_network_policy is defined and enable_network_policy == True

--- a/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      kubernetes.io/cluster-service: "true"
+      k8s-app: calico-policy
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        kubernetes.io/cluster-service: "true"
+        k8s-app: calico-policy
+    spec:
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          image: calico/kube-policy-controller:latest
+          env:
+            - name: ETCD_ENDPOINTS
+              value: "{{ etcd_endpoint }}"
+            # Location of the Kubernetes API - this shouldn't need to be
+            # changed so long as it is used in conjunction with
+            # CONFIGURE_ETC_HOSTS="true".
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Configure /etc/hosts within the container to resolve
+            # the kubernetes.default Service to the correct clusterIP
+            # using the environment provided by the kubelet.
+            # This removes the need for KubeDNS to resolve the Service.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -31,6 +31,9 @@ spec:
     - --runtime-config={{ conf }}
 {%   endfor %}
 {% endif %}
+{% if enable_network_policy is defined and enable_network_policy == True %}
+    - --runtime-config=extensions/v1beta1/networkpolicies=true
+{% endif %}
     - --v={{ kube_log_level | default('2') }}
     - --allow-privileged=true
 {% if cloud_provider is defined and cloud_provider == "openstack" %}

--- a/roles/kubernetes/node/templates/cni-calico.conf.j2
+++ b/roles/kubernetes/node/templates/cni-calico.conf.j2
@@ -5,6 +5,11 @@
   "ipam": {
     "type": "calico-ipam"
   },
+{% if enable_network_policy is defined and enable_network_policy == True %}
+  "policy": {
+    "type": "k8s"
+  },
+{% endif %}
   "kubernetes": {
     "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
   }


### PR DESCRIPTION
The requirements for network policy feature are described here [1]. In
order to enable it, appropriate configuration must be provided to the CNI
plug in and Calico policy controller must be set up. Beside that
corresponding extensions needed to be enabled in k8s API.

Now to turn on the feature user can define `enable_network_policy`
customization variable for Ansible.

[1] http://kubernetes.io/docs/user-guide/networkpolicies/

This PR fixes issue #159 