### PR TITLE
Use tar+register instead of copy/slurp for distributing tokens and certs

### DIFF
--- a/roles/kubernetes/secrets/tasks/gen_certs.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs.yml
@@ -27,31 +27,30 @@
     master_certs: ['ca-key.pem', 'admin.pem', 'admin-key.pem', 'apiserver-key.pem', 'apiserver.pem']
     node_certs: ['ca.pem', 'node.pem', 'node-key.pem']
 
-- name: Gen_certs | Get the certs from first master
-  slurp:
-    src: "{{ kube_cert_dir }}/{{ item }}"
+- name: Gen_certs | Gather master certs
+  shell: "tar cfz - -C {{ kube_cert_dir }} {{ master_certs|join(' ') }} {{ node_certs|join(' ') }} | base64 --wrap=0"
+  register: master_cert_data
   delegate_to: "{{groups['kube-master'][0]}}"
-  register: slurp_certs
-  with_items: '{{ master_certs + node_certs }}'
-  when: sync_certs|default(false)
   run_once: true
-  notify: set secret_changed
+  when: sync_certs|default(false)
+
+- name: Gen_certs | Gather node certs
+  shell: "tar cfz - -C {{ kube_cert_dir }} {{ node_certs|join(' ') }} | base64 --wrap=0"
+  register: node_cert_data
+  delegate_to: "{{groups['kube-master'][0]}}"
+  run_once: true
+  when: sync_certs|default(false)
 
 - name: Gen_certs | Copy certs on masters
-  copy:
-    content: "{{ item.content|b64decode }}"
-    dest: "{{ item.source }}"
-  with_items: '{{slurp_certs.results}}'
+  shell: "echo '{{master_cert_data.stdout|quote}}' | base64 -d | tar xz -C {{ kube_cert_dir }}"
+  changed_when: false
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
 
 - name: Gen_certs | Copy certs on nodes
-  copy:
-    content: "{{ item.content|b64decode }}"
-    dest: "{{ item.source }}"
-  with_items: '{{slurp_certs.results}}'
-  when: item.item in node_certs and
-        inventory_hostname in groups['kube-node'] and sync_certs|default(false) and
+  shell: "echo '{{node_cert_data.stdout|quote}}' | base64 -d | tar xz -C {{ kube_cert_dir }}"
+  changed_when: false
+  when: inventory_hostname in groups['kube-node'] and  sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
 
 - name: Gen_certs | check certificate permissions

--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -43,20 +43,15 @@
   delegate_to: "{{groups['kube-master'][0]}}"
   when: sync_tokens|default(false)
 
-- name: Gen_tokens | Get the tokens from first master
-  slurp:
-    src: "{{ item }}"
-  register: slurp_tokens
-  with_items: '{{tokens_list.stdout_lines}}'
-  run_once: true
+- name: Gen_tokens | Gather tokens
+  shell: "tar cfz - {{ tokens_list.stdout_lines | join(' ') }} | base64 --wrap=0"
+  register: tokens_data
   delegate_to: "{{groups['kube-master'][0]}}"
+  run_once: true
   when: sync_tokens|default(false)
-  notify: set secret_changed
 
 - name: Gen_tokens | Copy tokens on masters
-  copy:
-    content: "{{ item.content|b64decode }}"
-    dest: "{{ item.source }}"
-  with_items: '{{slurp_tokens.results}}'
+  shell: "echo '{{ tokens_data.stdout|quote }}' | base64 -d | tar xz -C /"
+  changed_when: false
   when: inventory_hostname in groups['kube-master'] and sync_tokens|default(false) and
         inventory_hostname != groups['kube-master'][0]


### PR DESCRIPTION
Related bug: ansible/ansible#15405

Uses tar and register because synchronize module cannot sudo on the
remote side correctly and copy is too slow.

This patch dramatically cuts down the number of tasks to process
for cert synchronization.