### PR TITLE
Add new var skip_dnsmasq_k8s

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -17,3 +17,9 @@ dnsmasq_version: 2.72
 # Images
 dnsmasq_image_repo: "andyshinn/dnsmasq"
 dnsmasq_image_tag: "{{ dnsmasq_version }}"
+
+# Skip dnsmasq setup
+skip_dnsmasq: false
+
+# Skip setting up dnsmasq daemonset
+skip_dnsmasq_k8s: "{{ skip_dnsmasq }}"

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - include: dnsmasq.yml
-  when: "{{ not skip_dnsmasq|bool }}"
+  when: "{{ not skip_dnsmasq_k8s|bool }}"
 
 - include: resolvconf.yml


### PR DESCRIPTION
If skip_dnsmasq is set, it will still not set up dnsmasq
k8s pod. This enables independent setup of resolvconf section
before kubelet is up.

Fixes #452